### PR TITLE
[fix] Actions で Dockerfile.prod をBuild, Prod に不要なGemを除外

### DIFF
--- a/.github/workflows/docker-build-prod.yaml
+++ b/.github/workflows/docker-build-prod.yaml
@@ -32,6 +32,7 @@ jobs:
         uses: docker/build-push-action@v4
         with:
           context: .
+          file: Dockerfile.prod
           platforms: linux/amd64,linux/arm64
           push: true
           tags: |

--- a/Dockerfile.prod
+++ b/Dockerfile.prod
@@ -14,7 +14,7 @@ RUN gem install rails -v 7.0.4 \
 
 COPY ./ /opt/app/
 
-RUN bundle install
+RUN bundle install --without development test
 
 EXPOSE 3000
 

--- a/Dockerfile.prod
+++ b/Dockerfile.prod
@@ -14,7 +14,9 @@ RUN gem install rails -v 7.0.4 \
 
 COPY ./ /opt/app/
 
-RUN bundle install --without development test
+ENV BUNDLE_WITHOUT development:test
+
+RUN bundle install
 
 EXPOSE 3000
 


### PR DESCRIPTION
## 概要
- Actions の workflow で Dockerfile.prod を Build するように修正
- 本番環境で dev/test のGemをinstallしないように指定

## 関連Issue
- close #13
