### PR TITLE
[feature] delete format option when converting image to binary string.

### DIFF
--- a/app/controllers/api/v1/texture/face_controller.rb
+++ b/app/controllers/api/v1/texture/face_controller.rb
@@ -3,14 +3,10 @@ class Api::V1::Texture::FaceController < ApplicationController
 		@face = Mineface::Face.new name: params[:id]
 		begin
 			@face.request!
-			@image_bin = @face.image.to_blob do
-				self.format = "PNG"
-			end
+			@image_bin = @face.image.to_blob
 		rescue => e
 			warn "[WARNING]: #{e.message}"
-			@image_bin = steve_face_image.to_blob do
-				self.format = "PNG"
-			end
+			@image_bin = steve_face_image.to_blob
 		end
 		send_data @image_bin, type: "image/png", disposition: 'inline'
 	end


### PR DESCRIPTION
## 概要
- Rmagick 後継対応のため binary として書き出すタイミングでの format option を削除

## 関連
- #4 
