### PR TITLE
[feature] cache-control header の適切な設定

### DIFF
--- a/app/controllers/api/v1/texture/face_controller.rb
+++ b/app/controllers/api/v1/texture/face_controller.rb
@@ -8,6 +8,8 @@ class Api::V1::Texture::FaceController < ApplicationController
 			warn "[WARNING]: #{e.message}"
 			@image_bin = steve_face_image.to_blob
 		end
+
+		expires_in 1.hours, public: true   # cache-control header.
 		send_data @image_bin, type: "image/png", disposition: 'inline'
 	end
 

--- a/spec/requests/api/v1/texture/face_spec.rb
+++ b/spec/requests/api/v1/texture/face_spec.rb
@@ -21,5 +21,17 @@ RSpec.describe "Api::V1::Texture::Faces", type: :request do
 				expect(response).to have_http_status(200)
 			end
 		end
+
+		context "response headers" do
+			it "have correct cache-control" do
+				# Act
+				get api_v1_texture_face_path("KrisJelbring")
+
+				# Assert
+				expect(response.headers).to be_present
+				expect(response.headers["Cache-Control"]).to include("public")
+				expect(response.headers["Cache-Control"]).to include("max-age=3600")
+			end
+		end
 	end
 end


### PR DESCRIPTION
## 背景
- Cloudflare でのキャッシュ設定を試みたがheaderの影響でcacheが効かなかった.

## この PR の内容
- 適切な cache-control header の付加
	- Cloudflare 曰く public で max-ageを0より大きくする必要がある
	- public
	- max-age=3600 (秒, )
- 付加した cache-control header のテスト (ヘッダーそれ自体のテスト, キャッシュされるかではない)

## このPRでやらないこと
- 他のエンドポイントでも同様のcache-controlが付加されること (共通化)
- 環境変数などで max-age の変更を容易にすること
- 実際にキャッシュされるかの検証

## 参照
- [Cache/CDN > Concepts > Default cache behavior : Cloudflare](https://developers.cloudflare.com/cache/concepts/default-cache-behavior/)
- [ActionController::ConditionalGet#expires_in : api.rubyonrails.org](https://api.rubyonrails.org/classes/ActionController/ConditionalGet.html#method-i-expires_in)


## 関連 Issue
- close #23 
