### PR TITLE
[feature] face api において拡張子のない request を bad request とする

### DIFF
--- a/app/controllers/api/v1/texture/face_controller.rb
+++ b/app/controllers/api/v1/texture/face_controller.rb
@@ -1,5 +1,10 @@
 class Api::V1::Texture::FaceController < ApplicationController
 	def show
+		unless File.extname(request.fullpath) == ".png"
+			render_status 400, {}, ["file extention must be '.png'"]
+			return nil
+		end
+
 		@face = Mineface::Face.new name: params[:id]
 		begin
 			@face.request!

--- a/app/controllers/api/v1/texture/face_controller.rb
+++ b/app/controllers/api/v1/texture/face_controller.rb
@@ -1,7 +1,7 @@
 class Api::V1::Texture::FaceController < ApplicationController
 	def show
 		unless File.extname(request.fullpath) == ".png"
-			render_status 400, {}, ["file extention must be '.png'"]
+			render json: {message: "file extention must be .png"}, status: 400
 			return nil
 		end
 

--- a/spec/requests/api/v1/texture/face_spec.rb
+++ b/spec/requests/api/v1/texture/face_spec.rb
@@ -5,7 +5,7 @@ RSpec.describe "Api::V1::Texture::Faces", type: :request do
 		context "give name of exist user to params" do
 			it "success 200" do
 				# Act
-				get api_v1_texture_face_path("KrisJelbring")
+				get api_v1_texture_face_path("KrisJelbring.png")
 
 				# Assert
 				expect(response).to have_http_status(200)
@@ -15,7 +15,7 @@ RSpec.describe "Api::V1::Texture::Faces", type: :request do
 		context "give name of none-exist user to params" do
 			it "success 200" do
 				# Act
-				get api_v1_texture_face_path("0")
+				get api_v1_texture_face_path("0.png")
 
 				# Assert
 				expect(response).to have_http_status(200)
@@ -25,7 +25,7 @@ RSpec.describe "Api::V1::Texture::Faces", type: :request do
 		context "response headers" do
 			it "have correct cache-control" do
 				# Act
-				get api_v1_texture_face_path("KrisJelbring")
+				get api_v1_texture_face_path("KrisJelbring.png")
 
 				# Assert
 				expect(response.headers).to be_present

--- a/spec/requests/api/v1/texture/face_spec.rb
+++ b/spec/requests/api/v1/texture/face_spec.rb
@@ -8,7 +8,7 @@ RSpec.describe "Api::V1::Texture::Faces", type: :request do
 				get api_v1_texture_face_path("KrisJelbring.png")
 
 				# Assert
-				expect(response).to have_http_status(200)
+				expect(response).to have_http_status 200
 			end
 		end
 
@@ -18,7 +18,39 @@ RSpec.describe "Api::V1::Texture::Faces", type: :request do
 				get api_v1_texture_face_path("0.png")
 
 				# Assert
-				expect(response).to have_http_status(200)
+				expect(response).to have_http_status 200
+			end
+		end
+
+		context "request with INCORRECT file extention" do
+			it "returns bad request 400" do
+				# Act
+				get api_v1_texture_face_path("KrisJelbring.PNG")
+
+				# Assert
+				json = JSON.parse(response.body)
+				expect(response).to have_http_status 400
+				
+				expect(json["status"]).to eq 400
+				expect(json["status_message"]).to eq "Bad Request"
+				expect(json["data"]).to eq({})
+				expect(json["messages"]).to eq ["file extention must be '.png'"]
+			end
+		end
+
+		context "request without file extention" do
+			it "returns bad request 400" do
+				# Act
+				get api_v1_texture_face_path("KrisJelbring")
+
+				# Assert
+				json = JSON.parse(response.body)
+				expect(response).to have_http_status 400
+				
+				expect(json["status"]).to eq 400
+				expect(json["status_message"]).to eq "Bad Request"
+				expect(json["data"]).to eq({})
+				expect(json["messages"]).to eq ["file extention must be '.png'"]
 			end
 		end
 

--- a/spec/requests/api/v1/texture/face_spec.rb
+++ b/spec/requests/api/v1/texture/face_spec.rb
@@ -30,11 +30,7 @@ RSpec.describe "Api::V1::Texture::Faces", type: :request do
 				# Assert
 				json = JSON.parse(response.body)
 				expect(response).to have_http_status 400
-				
-				expect(json["status"]).to eq 400
-				expect(json["status_message"]).to eq "Bad Request"
-				expect(json["data"]).to eq({})
-				expect(json["messages"]).to eq ["file extention must be '.png'"]
+				expect(json["message"]).to eq "file extention must be .png"
 			end
 		end
 
@@ -46,11 +42,7 @@ RSpec.describe "Api::V1::Texture::Faces", type: :request do
 				# Assert
 				json = JSON.parse(response.body)
 				expect(response).to have_http_status 400
-				
-				expect(json["status"]).to eq 400
-				expect(json["status_message"]).to eq "Bad Request"
-				expect(json["data"]).to eq({})
-				expect(json["messages"]).to eq ["file extention must be '.png'"]
+				expect(json["message"]).to eq "file extention must be .png"
 			end
 		end
 


### PR DESCRIPTION
## 背景
- Cloudflare では file extention のない request はキャッシュしない
- よって file extention ないリクエストを受けられない設計にしたい

## この PR の内容
- file extention をチェックして `.png` でなければ 400 にする処理追加
- 以上の変更で正常に動作しなくなったテストの修正
- テストの追加
