### PR TITLE
[feature] Face API に与えられたユーザー名が存在しない場合は 404 にしたい

### DIFF
--- a/app/controllers/api/v1/texture/face_controller.rb
+++ b/app/controllers/api/v1/texture/face_controller.rb
@@ -1,5 +1,6 @@
 class Api::V1::Texture::FaceController < ApplicationController
 	def show
+		@status = 200
 		unless File.extname(request.fullpath) == ".png"
 			render json: {message: "file extention must be .png"}, status: 400
 			return nil
@@ -12,10 +13,11 @@ class Api::V1::Texture::FaceController < ApplicationController
 		rescue => e
 			warn "[WARNING]: #{e.message}"
 			@image_bin = steve_face_image.to_blob
+			@status = 404
 		end
 
 		expires_in 1.hours, public: true   # cache-control header.
-		send_data @image_bin, type: "image/png", disposition: 'inline'
+		send_data @image_bin, type: "image/png", disposition: 'inline', status: @status
 	end
 
 	private def steve_face_image

--- a/spec/requests/api/v1/texture/face_spec.rb
+++ b/spec/requests/api/v1/texture/face_spec.rb
@@ -9,16 +9,18 @@ RSpec.describe "Api::V1::Texture::Faces", type: :request do
 
 				# Assert
 				expect(response).to have_http_status 200
+				expect(response.headers["Content-Type"]).to eq "image/png"
 			end
 		end
 
 		context "give name of none-exist user to params" do
-			it "success 200" do
+			it "not found 404" do
 				# Act
 				get api_v1_texture_face_path("0.png")
 
 				# Assert
-				expect(response).to have_http_status 200
+				expect(response).to have_http_status 404
+				expect(response.headers["Content-Type"]).to eq "image/png"
 			end
 		end
 
@@ -53,6 +55,7 @@ RSpec.describe "Api::V1::Texture::Faces", type: :request do
 
 				# Assert
 				expect(response.headers).to be_present
+				expect(response.headers["Content-Type"]).to eq "image/png"
 				expect(response.headers["Cache-Control"]).to include("public")
 				expect(response.headers["Cache-Control"]).to include("max-age=3600")
 			end


### PR DESCRIPTION
## 概要
- face api に対して存在しないユーザー名でrequestした場合のstatus code を404にしたい

## 変更詳細
- controller
	- status code を例外時に404にする実装
- rspec
	- face api の status code をチェックするテストケースの追加
	- mime-type のチェックのテストケースの追加

## 関連 Issue
- close #29 