### PR TITLE
[HOTFIX] tld_list.yaml の NO の要素を false として解釈してエラーになるケースの暫定対処

### DIFF
--- a/app/controllers/api/v1/servers/status_controller.rb
+++ b/app/controllers/api/v1/servers/status_controller.rb
@@ -92,8 +92,6 @@ class Api::V1::Servers::StatusController < ApplicationController
 		return true
 	end
 
-	[].map { |e|  }
-
 	private def _ip_address_filter_default _host
 		begin
 			_host_address = IPAddr.new(_host)

--- a/app/controllers/api/v1/servers/status_controller.rb
+++ b/app/controllers/api/v1/servers/status_controller.rb
@@ -86,9 +86,13 @@ class Api::V1::Servers::StatusController < ApplicationController
 		return false if _match.nil?
 
 		tld_list = App::Application.config.tld_list["TLD"]
-		raise ArgumentError, "given TLD of hostname is not correct." unless tld_list.map(&:upcase).include? _match[1]
+		unless tld_list.map{|i| i.to_s.upcase}.include? _match[1]
+			raise ArgumentError, "given TLD of hostname is not correct."
+		end
 		return true
 	end
+
+	[].map { |e|  }
 
 	private def _ip_address_filter_default _host
 		begin


### PR DESCRIPTION
## 問題概要
- tld_list.yaml の `.NO` ドメインの要素をyamlの仕様に則って false として扱ってしまう
- Stringに対して呼ばれるべき upcase メソッドが false に対して呼ばれてAPIがエラーを返している
- `undefined method `upcase' for false:FalseClass`

## **暫定対策**
- tld_list のすべての要素に対して `.to_s.upcase` することで、upcase String以外に対して呼ばれる可能性を下げる
- parse 後の tld_list に false が残っているので、存在しない `.false` ドメインを許可してしまっている状況。
