### PR TITLE
[refactor/fix] Server Status API から ACL クラスを分離, 単体テストの作成

### DIFF
--- a/app/controllers/api/v1/servers/status_controller.rb
+++ b/app/controllers/api/v1/servers/status_controller.rb
@@ -1,30 +1,30 @@
 class Api::V1::Servers::StatusController < ApplicationController
-	require 'ipaddr'
-	require 'yaml'
+	# require 'ipaddr'
+	# require 'yaml'
 
-	class DeniedHostError < StandardError
-		def initialize msg="Request to this host is not allowed."
-			super msg
-		end
-	end
+	# class DeniedHostError < StandardError
+	# 	def initialize msg="Request to this host is not allowed."
+	# 		super msg
+	# 	end
+	# end
 
-	DENY_IP_ADDRESSES = [
-		# IPv4
-		"192.168.0.0/16",
-		"172.16.0.0/12",
-		"10.0.0.0/8",
-		"255.255.255.255",   # broadcast
-		"127.0.0.0/8",   # loop back
-		"169.254.0.0/16",   # link local
-		"100.64.0.0/10",   # shared address space ref: RFC6890
+	# DENY_IP_ADDRESSES = [
+	# 	# IPv4
+	# 	"192.168.0.0/16",
+	# 	"172.16.0.0/12",
+	# 	"10.0.0.0/8",
+	# 	"255.255.255.255",   # broadcast
+	# 	"127.0.0.0/8",   # loop back
+	# 	"169.254.0.0/16",   # link local
+	# 	"100.64.0.0/10",   # shared address space ref: RFC6890
 
-		# IPv6
-		"::1/128",   # loop back
-		"fc00::/7",   # unique local
-		"fe80::/10",   # link local
-		"ff01::1",   # multicast on interface local
-		"ff02::1",   # multicast on link local
-	].freeze
+	# 	# IPv6
+	# 	"::1/128",   # loop back
+	# 	"fc00::/7",   # unique local
+	# 	"fe80::/10",   # link local
+	# 	"ff01::1",   # multicast on interface local
+	# 	"ff02::1",   # multicast on link local
+	# ].freeze
 
 	def index
 		@host = params[:host]
@@ -32,9 +32,10 @@ class Api::V1::Servers::StatusController < ApplicationController
 		@port = params[:port].to_i unless params[:port].nil?
 
 		begin
-			host_filter @host
+			@acl = Acl::Acl.new @host
+			@acl.filter!
 			@server = Minetools::ServerStatusTool::ServerStatus.new host: @host, port: @port
-		rescue DeniedHostError => e
+		rescue Acl::DeniedHostError => e
 			render status: 400, json: {message: e.message}
 			return
 		rescue ArgumentError => e
@@ -71,36 +72,36 @@ class Api::V1::Servers::StatusController < ApplicationController
 		}
 	end
 
-	private	def host_filter _host
-		raise ArgumentError unless _host.class == String
-		# TODO: fastly return with white list
+	# private	def host_filter _host
+	# 	raise ArgumentError unless _host.class == String
+	# 	# TODO: fastly return with white list
 
-		is_hostname = _host_name_filter_default _host
-		is_ipaddr = _ip_address_filter_default _host
+	# 	is_hostname = _host_name_filter_default _host
+	# 	is_ipaddr = _ip_address_filter_default _host
 
-		raise ArgumentError, "given host is not IP address or correct hostname." if !is_ipaddr && !is_hostname
-	end
+	# 	raise ArgumentError, "given host is not IP address or correct hostname." if !is_ipaddr && !is_hostname
+	# end
 
-	private def _host_name_filter_default _host
-		_match = /^(?:[a-zA-Z0-9][a-zA-Z0-9-]{,63}[a-zA-Z0-9]{,63}\.){,253}([a-zA-Z]{2,})$/.match _host.upcase
-		return false if _match.nil?
+	# private def _host_name_filter_default _host
+	# 	_match = /^(?:[a-zA-Z0-9][a-zA-Z0-9-]{,63}[a-zA-Z0-9]{,63}\.){,253}([a-zA-Z]{2,})$/.match _host.upcase
+	# 	return false if _match.nil?
 
-		tld_list = App::Application.config.tld_list["TLD"]
-		unless tld_list.map{|i| i.to_s.upcase}.include? _match[1]
-			raise ArgumentError, "given TLD of hostname is not correct."
-		end
-		return true
-	end
+	# 	tld_list = App::Application.config.tld_list["TLD"]
+	# 	unless tld_list.map{|i| i.to_s.upcase}.include? _match[1]
+	# 		raise ArgumentError, "given TLD of hostname is not correct."
+	# 	end
+	# 	return true
+	# end
 
-	private def _ip_address_filter_default _host
-		begin
-			_host_address = IPAddr.new(_host)
-		rescue IPAddr::InvalidAddressError => e
-			return false
-		end
-		DENY_IP_ADDRESSES.each do |addr|
-			raise DeniedHostError if IPAddr.new(addr).include? _host_address
-		end
-		return true
-	end
+	# private def _ip_address_filter_default _host
+	# 	begin
+	# 		_host_address = IPAddr.new(_host)
+	# 	rescue IPAddr::InvalidAddressError => e
+	# 		return false
+	# 	end
+	# 	DENY_IP_ADDRESSES.each do |addr|
+	# 		raise DeniedHostError if IPAddr.new(addr).include? _host_address
+	# 	end
+	# 	return true
+	# end
 end

--- a/app/controllers/api/v1/servers/status_controller.rb
+++ b/app/controllers/api/v1/servers/status_controller.rb
@@ -1,12 +1,13 @@
 class Api::V1::Servers::StatusController < ApplicationController
 	def index
+		@tld_list = App::Application.config.tld_list["TLD"]
 		@host = params[:host]
 		@port = nil
 		@port = params[:port].to_i unless params[:port].nil?
 
 		begin
 
-			@acl = Acl::Acl.new @host
+			@acl = Acl::Acl.new @host, @tld_list
 			@acl.filter!
 			@server = Minetools::ServerStatusTool::ServerStatus.new host: @host, port: @port
 			@server.fetch_status!

--- a/app/controllers/api/v1/servers/status_controller.rb
+++ b/app/controllers/api/v1/servers/status_controller.rb
@@ -1,53 +1,22 @@
 class Api::V1::Servers::StatusController < ApplicationController
-	# require 'ipaddr'
-	# require 'yaml'
-
-	# class DeniedHostError < StandardError
-	# 	def initialize msg="Request to this host is not allowed."
-	# 		super msg
-	# 	end
-	# end
-
-	# DENY_IP_ADDRESSES = [
-	# 	# IPv4
-	# 	"192.168.0.0/16",
-	# 	"172.16.0.0/12",
-	# 	"10.0.0.0/8",
-	# 	"255.255.255.255",   # broadcast
-	# 	"127.0.0.0/8",   # loop back
-	# 	"169.254.0.0/16",   # link local
-	# 	"100.64.0.0/10",   # shared address space ref: RFC6890
-
-	# 	# IPv6
-	# 	"::1/128",   # loop back
-	# 	"fc00::/7",   # unique local
-	# 	"fe80::/10",   # link local
-	# 	"ff01::1",   # multicast on interface local
-	# 	"ff02::1",   # multicast on link local
-	# ].freeze
-
 	def index
 		@host = params[:host]
 		@port = nil
 		@port = params[:port].to_i unless params[:port].nil?
 
 		begin
+
 			@acl = Acl::Acl.new @host
 			@acl.filter!
 			@server = Minetools::ServerStatusTool::ServerStatus.new host: @host, port: @port
-		rescue Acl::DeniedHostError => e
-			render status: 400, json: {message: e.message}
-			return
+			@server.fetch_status!
+
 		rescue ArgumentError => e
 			render status: 400, json: {message: e.message}
 			return
-		rescue => e
-			render status: 500, json: {message: e.message}
+		rescue Acl::DeniedHostError => e
+			render status: 400, json: {message: e.message}
 			return
-		end
-
-		begin
-			@server.fetch_status!
 		rescue Minetools::ServerStatusTool::ServiceUnavailableError => e
 			render status: 404, json: {message: e.message}
 			return
@@ -71,37 +40,4 @@ class Api::V1::Servers::StatusController < ApplicationController
 			players: _status["players"]["sample"]
 		}
 	end
-
-	# private	def host_filter _host
-	# 	raise ArgumentError unless _host.class == String
-	# 	# TODO: fastly return with white list
-
-	# 	is_hostname = _host_name_filter_default _host
-	# 	is_ipaddr = _ip_address_filter_default _host
-
-	# 	raise ArgumentError, "given host is not IP address or correct hostname." if !is_ipaddr && !is_hostname
-	# end
-
-	# private def _host_name_filter_default _host
-	# 	_match = /^(?:[a-zA-Z0-9][a-zA-Z0-9-]{,63}[a-zA-Z0-9]{,63}\.){,253}([a-zA-Z]{2,})$/.match _host.upcase
-	# 	return false if _match.nil?
-
-	# 	tld_list = App::Application.config.tld_list["TLD"]
-	# 	unless tld_list.map{|i| i.to_s.upcase}.include? _match[1]
-	# 		raise ArgumentError, "given TLD of hostname is not correct."
-	# 	end
-	# 	return true
-	# end
-
-	# private def _ip_address_filter_default _host
-	# 	begin
-	# 		_host_address = IPAddr.new(_host)
-	# 	rescue IPAddr::InvalidAddressError => e
-	# 		return false
-	# 	end
-	# 	DENY_IP_ADDRESSES.each do |addr|
-	# 		raise DeniedHostError if IPAddr.new(addr).include? _host_address
-	# 	end
-	# 	return true
-	# end
 end

--- a/lib/acl/acl.rb
+++ b/lib/acl/acl.rb
@@ -1,0 +1,6 @@
+module Acl
+	class Acl
+		def initialize
+		end
+	end
+end

--- a/lib/acl/acl.rb
+++ b/lib/acl/acl.rb
@@ -48,7 +48,7 @@ module Acl
 			return false if _match.nil?
 
 			unless @tld_list.map{|i| i.to_s.upcase}.include? _match[1]
-				raise ArgumentError, "given TLD of hostname is not correct."
+				raise DeniedHostError, "given TLD of hostname is not correct."
 			end
 			return true
 		end
@@ -60,7 +60,7 @@ module Acl
 				return false
 			end
 			DENY_IP_ADDRESSES.each do |addr|
-				raise DeniedHostError if IPAddr.new(addr).include? _host_address
+				raise DeniedHostError, "given IP Address is not allowed length." if IPAddr.new(addr).include? _host_address
 			end
 			return true
 		end

--- a/lib/acl/acl.rb
+++ b/lib/acl/acl.rb
@@ -1,6 +1,72 @@
 module Acl
 	class Acl
-		def initialize
+		require 'ipaddr'
+		require 'yaml'
+
+		DENY_IP_ADDRESSES = [
+			# IPv4
+			"192.168.0.0/16",
+			"172.16.0.0/12",
+			"10.0.0.0/8",
+			"255.255.255.255",   # broadcast
+			"127.0.0.0/8",   # loop back
+			"169.254.0.0/16",   # link local
+			"100.64.0.0/10",   # shared address space ref: RFC6890
+
+			# IPv6
+			"::1/128",   # loop back
+			"fc00::/7",   # unique local
+			"fe80::/10",   # link local
+			"ff01::1",   # multicast on interface local
+			"ff02::1",   # multicast on link local
+		].freeze
+
+		def initialize host=nil
+			raise ArgumentError unless host.class == String
+			@host = host
+		end
+
+		def filter!
+			filter @host
+		end
+
+		def filter _host
+			raise ArgumentError unless _host.class == String
+			# TODO: fastly return with white list
+
+			is_hostname = _host_name_filter_default _host
+			is_ipaddr = _ip_address_filter_default _host
+
+			raise ArgumentError, "given host is not IP address or correct hostname." if !is_ipaddr && !is_hostname
+		end
+
+		def _host_name_filter_default _host
+			_match = /^(?:[a-zA-Z0-9][a-zA-Z0-9-]{,63}[a-zA-Z0-9]{,63}\.){,253}([a-zA-Z]{2,})$/.match _host.upcase
+			return false if _match.nil?
+
+			tld_list = App::Application.config.tld_list["TLD"]
+			unless tld_list.map{|i| i.to_s.upcase}.include? _match[1]
+				raise ArgumentError, "given TLD of hostname is not correct."
+			end
+			return true
+		end
+
+		def _ip_address_filter_default _host
+			begin
+				_host_address = IPAddr.new(_host)
+			rescue IPAddr::InvalidAddressError => e
+				return false
+			end
+			DENY_IP_ADDRESSES.each do |addr|
+				raise DeniedHostError if IPAddr.new(addr).include? _host_address
+			end
+			return true
+		end
+	end
+
+	class DeniedHostError < StandardError
+		def initialize msg="Request to this host is not allowed."
+			super msg
 		end
 	end
 end

--- a/lib/acl/acl.rb
+++ b/lib/acl/acl.rb
@@ -67,10 +67,10 @@ module Acl
 		private def is_tld_array? _array
 			return false unless _array.class == Array
 			return false if _array.size < 1
-			_array.each do |_tld|
+			# _array.each do |_tld|   # Issue #53
 				# TODO: check simple domains or XN== domains or not.
-				return false unless _tld.class == String
-			end
+				# return false unless _tld.class == String
+			# end
 			return true
 		end
 	end

--- a/lib/acl/acl.rb
+++ b/lib/acl/acl.rb
@@ -23,7 +23,6 @@ module Acl
 
 		def initialize host=nil, tld_list=[]
 			raise ArgumentError unless host.class == String
-			raise ArgumentError unless tld_list.class == Array
 			raise ArgumentError unless is_tld_array? tld_list
 			@host = host
 			@tld_list = tld_list
@@ -33,7 +32,7 @@ module Acl
 			filter @host
 		end
 
-		def filter _host
+		private def filter _host
 			raise ArgumentError unless _host.class == String
 			# TODO: fastly return with white list
 
@@ -43,7 +42,7 @@ module Acl
 			raise ArgumentError, "given host is not IP address or correct hostname." if !is_ipaddr && !is_hostname
 		end
 
-		def _host_name_filter_default _host
+		private def _host_name_filter_default _host
 			_match = /^(?:[a-zA-Z0-9][a-zA-Z0-9-]{,63}[a-zA-Z0-9]{,63}\.){,253}([a-zA-Z]{2,})$/.match _host.upcase
 			return false if _match.nil?
 
@@ -53,7 +52,7 @@ module Acl
 			return true
 		end
 
-		def _ip_address_filter_default _host
+		private def _ip_address_filter_default _host
 			begin
 				_host_address = IPAddr.new(_host)
 			rescue IPAddr::InvalidAddressError => e

--- a/spec/lib/acl/acl_spec.rb
+++ b/spec/lib/acl/acl_spec.rb
@@ -3,7 +3,7 @@ require './lib/acl/acl.rb'
 
 RSpec.describe Acl::Acl do
 	it "is object of Acl::Acl class" do
-		acl = Acl::Acl.new
+		acl = Acl::Acl.new ""
 		expect(acl.class).to eq(Acl::Acl)
 	end
 end

--- a/spec/lib/acl/acl_spec.rb
+++ b/spec/lib/acl/acl_spec.rb
@@ -367,4 +367,56 @@ RSpec.describe Acl::Acl do
 			end
 		end
 	end
+
+	describe "CONST_VALUES" do
+		describe "DENY_IP_ADDRESSES" do
+			context "IPv4" do
+				it "contains 192.168.0.0/16" do
+					expect(Acl::Acl::DENY_IP_ADDRESSES).to include("192.168.0.0/16")
+				end
+
+				it "contains 172.16.0.0/12" do
+					expect(Acl::Acl::DENY_IP_ADDRESSES).to include("172.16.0.0/12")
+				end
+
+				it "contains 10.0.0.0/8" do
+					expect(Acl::Acl::DENY_IP_ADDRESSES).to include("10.0.0.0/8")
+				end
+
+				it "contains 255.255.255.255 broadcast" do
+					expect(Acl::Acl::DENY_IP_ADDRESSES).to include("255.255.255.255")
+				end
+
+				it "contains 127.0.0.0/8 loop back" do
+					expect(Acl::Acl::DENY_IP_ADDRESSES).to include("127.0.0.0/8")
+				end
+
+				it "contains 169.254.0.0/16 link local" do
+					expect(Acl::Acl::DENY_IP_ADDRESSES).to include("169.254.0.0/16")
+				end
+
+				it "contains 100.64.0.0/10 shared address space ref: RFC6890" do
+					expect(Acl::Acl::DENY_IP_ADDRESSES).to include("100.64.0.0/10")
+				end
+			end
+
+			context "IPv6" do
+				it "contains ::1/128 loop back" do
+					expect(Acl::Acl::DENY_IP_ADDRESSES).to include("::1/128")
+				end
+				it "contains fc00::/7 unique local" do
+					expect(Acl::Acl::DENY_IP_ADDRESSES).to include("fc00::/7")
+				end
+				it "contains fe80::/10 link local" do
+					expect(Acl::Acl::DENY_IP_ADDRESSES).to include("fe80::/10")
+				end
+				it "contains ff01::1 multicast on interface local" do
+					expect(Acl::Acl::DENY_IP_ADDRESSES).to include("ff01::1")
+				end
+				it "contains ff02::1 multicast on link local" do
+					expect(Acl::Acl::DENY_IP_ADDRESSES).to include("ff02::1")
+				end
+			end
+		end
+	end
 end

--- a/spec/lib/acl/acl_spec.rb
+++ b/spec/lib/acl/acl_spec.rb
@@ -3,13 +3,57 @@ require './lib/acl/acl.rb'
 
 RSpec.describe Acl::Acl do
 	it "is object of Acl::Acl class" do
-		acl = Acl::Acl.new "", App::Application.config.tld_list["TLD"]
+		acl = Acl::Acl.new "example.com", App::Application.config.tld_list["TLD"]
 		expect(acl.class).to eq(Acl::Acl)
 	end
 
 	describe "methods" do
 		describe "initialize()" do
-			
+			context "errors" do
+				context "host ArgumentError" do
+					it "raise error by host is number." do
+						expect{Acl::Acl.new 1, ["COM"]}.to raise_error ArgumentError
+					end
+
+					it "raise error by host is nil." do
+						expect{Acl::Acl.new nil, ["COM"]}.to raise_error ArgumentError
+					end
+
+					it "raise error by host is false." do
+						expect{Acl::Acl.new false, ["COM"]}.to raise_error ArgumentError
+					end
+
+					it "raise error by host is true." do
+						expect{Acl::Acl.new true, ["COM"]}.to raise_error ArgumentError
+					end
+				end
+
+				context "tld_list ArgumentError" do
+					it "raise error by tld_list is hash." do
+						expect{Acl::Acl.new "example.com", {"COM" => true}}.to raise_error ArgumentError
+					end
+
+					it "raise error by tld_list is nil." do
+						expect{Acl::Acl.new "example.com", nil}.to raise_error ArgumentError
+					end
+
+					it "raise error by tld_list is false." do
+						expect{Acl::Acl.new "example.com", false}.to raise_error ArgumentError
+					end
+
+					it "raise error by tld_list is true." do
+						expect{Acl::Acl.new "example.com", true}.to raise_error ArgumentError
+					end
+
+					it "raise error by tld_list is empty Array []." do
+						expect{Acl::Acl.new "example.com", []}.to raise_error ArgumentError
+					end
+
+					it "raise error by tld_list is Array of numbers." do
+						expect{Acl::Acl.new "example.com", [1,2,3]}.to raise_error ArgumentError
+					end
+				end
+			end
 		end
 
 		describe "filter!" do

--- a/spec/lib/acl/acl_spec.rb
+++ b/spec/lib/acl/acl_spec.rb
@@ -1,0 +1,9 @@
+require 'rails_helper'
+require './lib/acl/acl.rb'
+
+RSpec.describe Acl::Acl do
+	it "is object of Acl::Acl class" do
+		acl = Acl::Acl.new
+		expect(acl.class).to eq(Acl::Acl)
+	end
+end

--- a/spec/lib/acl/acl_spec.rb
+++ b/spec/lib/acl/acl_spec.rb
@@ -13,286 +13,312 @@ RSpec.describe Acl::Acl do
 		end
 
 		describe "filter!" do
-			context "deny cases by ip address" do
-				context "IPv4 local addresses" do
-					context "192.168.x.x" do
-						it "will deny with 192.168.0.0" do
-							acl = Acl::Acl.new "192.168.0.0", ["COM"]
-							expect{acl.filter!}.to raise_error Acl::DeniedHostError, "given IP Address is not allowed length."
+			context "deny cases" do
+				context "deny cases by ip address" do
+					context "IPv4 local addresses" do
+						context "192.168.x.x" do
+							it "will deny with 192.168.0.0" do
+								acl = Acl::Acl.new "192.168.0.0", ["COM"]
+								expect{acl.filter!}.to raise_error Acl::DeniedHostError, "given IP Address is not allowed length."
+							end
+
+							it "will deny with 192.168.0.1" do
+								acl = Acl::Acl.new "192.168.0.1", ["COM"]
+								expect{acl.filter!}.to raise_error Acl::DeniedHostError, "given IP Address is not allowed length."
+							end
+
+							it "will deny with 192.168.255.254" do
+								acl = Acl::Acl.new "192.168.255.254", ["COM"]
+								expect{acl.filter!}.to raise_error Acl::DeniedHostError, "given IP Address is not allowed length."
+							end
+
+							it "will deny with 192.168.255.255" do
+								acl = Acl::Acl.new "192.168.255.255", ["COM"]
+								expect{acl.filter!}.to raise_error Acl::DeniedHostError, "given IP Address is not allowed length."
+							end
+
+							it "will deny with 192.168.24.10 (No reason)" do
+								acl = Acl::Acl.new "192.168.24.10", ["COM"]
+								expect{acl.filter!}.to raise_error Acl::DeniedHostError, "given IP Address is not allowed length."
+							end
 						end
 
-						it "will deny with 192.168.0.1" do
-							acl = Acl::Acl.new "192.168.0.1", ["COM"]
-							expect{acl.filter!}.to raise_error Acl::DeniedHostError, "given IP Address is not allowed length."
+						context "172.16.x.x ~ 172.31.x.x" do
+							it "will deny with 172.16.0.0" do
+								acl = Acl::Acl.new "172.16.0.0", ["COM"]
+								expect{acl.filter!}.to raise_error Acl::DeniedHostError, "given IP Address is not allowed length."
+							end
+
+							it "will deny with 172.16.0.1" do
+								acl = Acl::Acl.new "172.16.0.1", ["COM"]
+								expect{acl.filter!}.to raise_error Acl::DeniedHostError, "given IP Address is not allowed length."
+							end
+
+							it "will deny with 172.31.255.254" do
+								acl = Acl::Acl.new "172.31.255.254", ["COM"]
+								expect{acl.filter!}.to raise_error Acl::DeniedHostError, "given IP Address is not allowed length."
+							end
+
+							it "will deny with 172.31.255.255" do
+								acl = Acl::Acl.new "172.31.255.255", ["COM"]
+								expect{acl.filter!}.to raise_error Acl::DeniedHostError, "given IP Address is not allowed length."
+							end
+
+							it "will deny with 172.24.1.24 (No reason)" do
+								acl = Acl::Acl.new "172.24.1.24", ["COM"]
+								expect{acl.filter!}.to raise_error Acl::DeniedHostError, "given IP Address is not allowed length."
+							end
 						end
 
-						it "will deny with 192.168.255.254" do
-							acl = Acl::Acl.new "192.168.255.254", ["COM"]
-							expect{acl.filter!}.to raise_error Acl::DeniedHostError, "given IP Address is not allowed length."
-						end
+						context "10.x.x.x" do
+							it "will deny with 10.0.0.0" do
+								acl = Acl::Acl.new "10.0.0.0", ["COM"]
+								expect{acl.filter!}.to raise_error Acl::DeniedHostError, "given IP Address is not allowed length."
+							end
 
-						it "will deny with 192.168.255.255" do
-							acl = Acl::Acl.new "192.168.255.255", ["COM"]
-							expect{acl.filter!}.to raise_error Acl::DeniedHostError, "given IP Address is not allowed length."
-						end
+							it "will deny with 10.0.0.1" do
+								acl = Acl::Acl.new "10.0.0.1", ["COM"]
+								expect{acl.filter!}.to raise_error Acl::DeniedHostError, "given IP Address is not allowed length."
+							end
 
-						it "will deny with 192.168.24.10 (No reason)" do
-							acl = Acl::Acl.new "192.168.24.10", ["COM"]
+							it "will deny with 10.255.255.254" do
+								acl = Acl::Acl.new "10.255.255.254", ["COM"]
+								expect{acl.filter!}.to raise_error Acl::DeniedHostError, "given IP Address is not allowed length."
+							end
+
+							it "will deny with 10.255.255.255" do
+								acl = Acl::Acl.new "10.255.255.255", ["COM"]
+								expect{acl.filter!}.to raise_error Acl::DeniedHostError, "given IP Address is not allowed length."
+							end
+
+							it "will deny with 10.10.192.31 (No reason)" do
+								acl = Acl::Acl.new "10.10.192.31", ["COM"]
+								expect{acl.filter!}.to raise_error Acl::DeniedHostError, "given IP Address is not allowed length."
+							end
+						end
+					end
+
+					context "IPv4 broadcast address" do
+						it "will deny with 255.255.255.255" do
+							acl = Acl::Acl.new "255.255.255.255", ["COM"]
 							expect{acl.filter!}.to raise_error Acl::DeniedHostError, "given IP Address is not allowed length."
 						end
 					end
 
-					context "172.16.x.x ~ 172.31.x.x" do
-						it "will deny with 172.16.0.0" do
-							acl = Acl::Acl.new "172.16.0.0", ["COM"]
+					context "IPv4 loop-back addresses" do
+						it "will deny with 127.0.0.0" do
+							acl = Acl::Acl.new "127.0.0.0", ["COM"]
 							expect{acl.filter!}.to raise_error Acl::DeniedHostError, "given IP Address is not allowed length."
 						end
 
-						it "will deny with 172.16.0.1" do
-							acl = Acl::Acl.new "172.16.0.1", ["COM"]
+						it "will deny with 127.0.0.1" do
+							acl = Acl::Acl.new "127.0.0.1", ["COM"]
 							expect{acl.filter!}.to raise_error Acl::DeniedHostError, "given IP Address is not allowed length."
 						end
 
-						it "will deny with 172.31.255.254" do
-							acl = Acl::Acl.new "172.31.255.254", ["COM"]
+						it "will deny with 127.255.255.254" do
+							acl = Acl::Acl.new "127.255.255.254", ["COM"]
 							expect{acl.filter!}.to raise_error Acl::DeniedHostError, "given IP Address is not allowed length."
 						end
 
-						it "will deny with 172.31.255.255" do
-							acl = Acl::Acl.new "172.31.255.255", ["COM"]
+						it "will deny with 127.255.255.255" do
+							acl = Acl::Acl.new "127.255.255.255", ["COM"]
 							expect{acl.filter!}.to raise_error Acl::DeniedHostError, "given IP Address is not allowed length."
 						end
 
-						it "will deny with 172.24.1.24 (No reason)" do
-							acl = Acl::Acl.new "172.24.1.24", ["COM"]
+						it "will deny with 127.0.0.53 (No reason)" do
+							acl = Acl::Acl.new "127.0.0.53", ["COM"]
 							expect{acl.filter!}.to raise_error Acl::DeniedHostError, "given IP Address is not allowed length."
 						end
 					end
 
-					context "10.x.x.x" do
-						it "will deny with 10.0.0.0" do
-							acl = Acl::Acl.new "10.0.0.0", ["COM"]
+					context "IPv4 link-local address" do
+						it "will deny with 169.254.0.0" do
+							acl = Acl::Acl.new "169.254.0.0", ["COM"]
 							expect{acl.filter!}.to raise_error Acl::DeniedHostError, "given IP Address is not allowed length."
 						end
 
-						it "will deny with 10.0.0.1" do
-							acl = Acl::Acl.new "10.0.0.1", ["COM"]
+						it "will deny with 169.254.0.1" do
+							acl = Acl::Acl.new "169.254.0.1", ["COM"]
 							expect{acl.filter!}.to raise_error Acl::DeniedHostError, "given IP Address is not allowed length."
 						end
 
-						it "will deny with 10.255.255.254" do
-							acl = Acl::Acl.new "10.255.255.254", ["COM"]
+						it "will deny with 169.254.255.254" do
+							acl = Acl::Acl.new "169.254.255.254", ["COM"]
 							expect{acl.filter!}.to raise_error Acl::DeniedHostError, "given IP Address is not allowed length."
 						end
 
-						it "will deny with 10.255.255.255" do
-							acl = Acl::Acl.new "10.255.255.255", ["COM"]
+						it "will deny with 169.254.255.255" do
+							acl = Acl::Acl.new "169.254.255.255", ["COM"]
 							expect{acl.filter!}.to raise_error Acl::DeniedHostError, "given IP Address is not allowed length."
 						end
 
-						it "will deny with 10.10.192.31 (No reason)" do
-							acl = Acl::Acl.new "10.10.192.31", ["COM"]
+						it "will deny with 169.254.1.10 (No reason)" do
+							acl = Acl::Acl.new "169.254.1.10", ["COM"]
+							expect{acl.filter!}.to raise_error Acl::DeniedHostError, "given IP Address is not allowed length."
+						end
+					end
+
+					context "IPv4 shared address space" do
+						it "will deny with 100.64.0.0" do
+							acl = Acl::Acl.new "100.64.0.0", ["COM"]
+							expect{acl.filter!}.to raise_error Acl::DeniedHostError, "given IP Address is not allowed length."
+						end
+
+						it "will deny with 100.64.0.1" do
+							acl = Acl::Acl.new "100.64.0.1", ["COM"]
+							expect{acl.filter!}.to raise_error Acl::DeniedHostError, "given IP Address is not allowed length."
+						end
+
+						it "will deny with 100.127.255.254" do
+							acl = Acl::Acl.new "100.127.255.254", ["COM"]
+							expect{acl.filter!}.to raise_error Acl::DeniedHostError, "given IP Address is not allowed length."
+						end
+
+						it "will deny with 100.127.255.255" do
+							acl = Acl::Acl.new "100.127.255.255", ["COM"]
+							expect{acl.filter!}.to raise_error Acl::DeniedHostError, "given IP Address is not allowed length."
+						end
+
+						it "will deny with 100.96.64.32" do
+							acl = Acl::Acl.new "100.96.64.32", ["COM"]
+							expect{acl.filter!}.to raise_error Acl::DeniedHostError, "given IP Address is not allowed length."
+						end
+					end
+
+					context "IPv6 loop-back" do
+						it "will deny with ::1" do
+							acl = Acl::Acl.new "::1", ["COM"]
+							expect{acl.filter!}.to raise_error Acl::DeniedHostError, "given IP Address is not allowed length."
+						end
+					end
+
+					context "IPv6 unique local addresses" do
+						it "will deny with fc00:0000:0000:0000:0000:0000:0000:0000" do
+							acl = Acl::Acl.new "fc00:0000:0000:0000:0000:0000:0000:0000", ["COM"]
+							expect{acl.filter!}.to raise_error Acl::DeniedHostError, "given IP Address is not allowed length."
+						end
+
+						it "will deny with fc00:0000:0000:0000:0000:0000:0000:0001" do
+							acl = Acl::Acl.new "fc00:0000:0000:0000:0000:0000:0000:0001", ["COM"]
+							expect{acl.filter!}.to raise_error Acl::DeniedHostError, "given IP Address is not allowed length."
+						end
+
+						it "will deny with fdff:ffff:ffff:ffff:ffff:ffff:ffff:fffe" do
+							acl = Acl::Acl.new "fdff:ffff:ffff:ffff:ffff:ffff:ffff:fffe", ["COM"]
+							expect{acl.filter!}.to raise_error Acl::DeniedHostError, "given IP Address is not allowed length."
+						end
+
+						it "will deny with fdff:ffff:ffff:ffff:ffff:ffff:ffff:ffff" do
+							acl = Acl::Acl.new "fdff:ffff:ffff:ffff:ffff:ffff:ffff:ffff", ["COM"]
+							expect{acl.filter!}.to raise_error Acl::DeniedHostError, "given IP Address is not allowed length."
+						end
+
+						it "will deny with fd00:cafe:cafe:cafe:cafe:cafe:cafe:cafe (No reason)" do
+							acl = Acl::Acl.new "fd00:cafe:cafe:cafe:cafe:cafe:cafe:cafe", ["COM"]
+							expect{acl.filter!}.to raise_error Acl::DeniedHostError, "given IP Address is not allowed length."
+						end
+					end
+
+					context "IPv6 link local addresses" do
+						it "will deny with fe80:0000:0000:0000:0000:0000:0000:0000" do
+							acl = Acl::Acl.new "fe80:0000:0000:0000:0000:0000:0000:0000", ["COM"]
+							expect{acl.filter!}.to raise_error Acl::DeniedHostError, "given IP Address is not allowed length."
+						end
+
+						it "will deny with fe80:0000:0000:0000:0000:0000:0000:0001" do
+							acl = Acl::Acl.new "fe80:0000:0000:0000:0000:0000:0000:0001", ["COM"]
+							expect{acl.filter!}.to raise_error Acl::DeniedHostError, "given IP Address is not allowed length."
+						end
+
+						it "will deny with febf:ffff:ffff:ffff:ffff:ffff:ffff:fffe" do
+							acl = Acl::Acl.new "febf:ffff:ffff:ffff:ffff:ffff:ffff:fffe", ["COM"]
+							expect{acl.filter!}.to raise_error Acl::DeniedHostError, "given IP Address is not allowed length."
+						end
+
+						it "will deny with febf:ffff:ffff:ffff:ffff:ffff:ffff:ffff" do
+							acl = Acl::Acl.new "febf:ffff:ffff:ffff:ffff:ffff:ffff:ffff", ["COM"]
+							expect{acl.filter!}.to raise_error Acl::DeniedHostError, "given IP Address is not allowed length."
+						end
+
+						it "will deny with febf:beef:beef:beef:beef:beef:beef:beef (No reason)" do
+							acl = Acl::Acl.new "febf:beef:beef:beef:beef:beef:beef:beef", ["COM"]
+							expect{acl.filter!}.to raise_error Acl::DeniedHostError, "given IP Address is not allowed length."
+						end
+					end
+
+					context "IPv6 multicast address on interface local" do
+						it "will deny with ff01::1" do
+							acl = Acl::Acl.new "ff01::1", ["COM"]
+							expect{acl.filter!}.to raise_error Acl::DeniedHostError, "given IP Address is not allowed length."
+						end
+
+						it "will deny with ff01:0000:0000:0000:0000:0000:0000:0001" do
+							acl = Acl::Acl.new "ff01:0000:0000:0000:0000:0000:0000:0001", ["COM"]
+							expect{acl.filter!}.to raise_error Acl::DeniedHostError, "given IP Address is not allowed length."
+						end
+					end
+
+					context "IPv6 multicast address on link local" do
+						it "will deny with ff02::1" do
+							acl = Acl::Acl.new "ff01::1", ["COM"]
+							expect{acl.filter!}.to raise_error Acl::DeniedHostError, "given IP Address is not allowed length."
+						end
+
+						it "will deny with ff02:0000:0000:0000:0000:0000:0000:0001" do
+							acl = Acl::Acl.new "ff01:0000:0000:0000:0000:0000:0000:0001", ["COM"]
 							expect{acl.filter!}.to raise_error Acl::DeniedHostError, "given IP Address is not allowed length."
 						end
 					end
 				end
 
-				context "IPv4 broadcast address" do
-					it "will deny with 255.255.255.255" do
-						acl = Acl::Acl.new "255.255.255.255", ["COM"]
-						expect{acl.filter!}.to raise_error Acl::DeniedHostError, "given IP Address is not allowed length."
+				context "deny cases by correct domains" do
+					it "will deny with not exsits top level domain" do
+						acl = Acl::Acl.new "minecraft.example.com.hogehoge", ["COM"]
+						expect{acl.filter!}.to raise_error Acl::DeniedHostError, "given TLD of hostname is not correct."
+					end
+
+					it "will deny with .local domain" do
+						acl = Acl::Acl.new "example.local", ["COM"]
+						expect{acl.filter!}.to raise_error Acl::DeniedHostError, "given TLD of hostname is not correct."
+					end
+
+					it "will deny with localhost domain" do
+						acl = Acl::Acl.new "localhost", ["COM"]
+						expect{acl.filter!}.to raise_error Acl::DeniedHostError, "given TLD of hostname is not correct."
 					end
 				end
 
-				context "IPv4 loop-back addresses" do
-					it "will deny with 127.0.0.0" do
-						acl = Acl::Acl.new "127.0.0.0", ["COM"]
-						expect{acl.filter!}.to raise_error Acl::DeniedHostError, "given IP Address is not allowed length."
-					end
-
-					it "will deny with 127.0.0.1" do
-						acl = Acl::Acl.new "127.0.0.1", ["COM"]
-						expect{acl.filter!}.to raise_error Acl::DeniedHostError, "given IP Address is not allowed length."
-					end
-
-					it "will deny with 127.255.255.254" do
-						acl = Acl::Acl.new "127.255.255.254", ["COM"]
-						expect{acl.filter!}.to raise_error Acl::DeniedHostError, "given IP Address is not allowed length."
-					end
-
-					it "will deny with 127.255.255.255" do
-						acl = Acl::Acl.new "127.255.255.255", ["COM"]
-						expect{acl.filter!}.to raise_error Acl::DeniedHostError, "given IP Address is not allowed length."
-					end
-
-					it "will deny with 127.0.0.53 (No reason)" do
-						acl = Acl::Acl.new "127.0.0.53", ["COM"]
-						expect{acl.filter!}.to raise_error Acl::DeniedHostError, "given IP Address is not allowed length."
+				context "deny cases by bad domain names" do
+					it "will deny with hogehoge-pc domain" do
+						# Can not parse as hostname and IPaddress.
+						acl = Acl::Acl.new "hogehoge-pc", ["COM"]
+						expect{acl.filter!}.to raise_error ArgumentError
 					end
 				end
 
-				context "IPv4 link-local address" do
-					it "will deny with 169.254.0.0" do
-						acl = Acl::Acl.new "169.254.0.0", ["COM"]
-						expect{acl.filter!}.to raise_error Acl::DeniedHostError, "given IP Address is not allowed length."
-					end
-
-					it "will deny with 169.254.0.1" do
-						acl = Acl::Acl.new "169.254.0.1", ["COM"]
-						expect{acl.filter!}.to raise_error Acl::DeniedHostError, "given IP Address is not allowed length."
-					end
-
-					it "will deny with 169.254.255.254" do
-						acl = Acl::Acl.new "169.254.255.254", ["COM"]
-						expect{acl.filter!}.to raise_error Acl::DeniedHostError, "given IP Address is not allowed length."
-					end
-
-					it "will deny with 169.254.255.255" do
-						acl = Acl::Acl.new "169.254.255.255", ["COM"]
-						expect{acl.filter!}.to raise_error Acl::DeniedHostError, "given IP Address is not allowed length."
-					end
-
-					it "will deny with 169.254.1.10 (No reason)" do
-						acl = Acl::Acl.new "169.254.1.10", ["COM"]
-						expect{acl.filter!}.to raise_error Acl::DeniedHostError, "given IP Address is not allowed length."
-					end
-				end
-
-				context "IPv4 shared address space" do
-					it "will deny with 100.64.0.0" do
-						acl = Acl::Acl.new "100.64.0.0", ["COM"]
-						expect{acl.filter!}.to raise_error Acl::DeniedHostError, "given IP Address is not allowed length."
-					end
-
-					it "will deny with 100.64.0.1" do
-						acl = Acl::Acl.new "100.64.0.1", ["COM"]
-						expect{acl.filter!}.to raise_error Acl::DeniedHostError, "given IP Address is not allowed length."
-					end
-
-					it "will deny with 100.127.255.254" do
-						acl = Acl::Acl.new "100.127.255.254", ["COM"]
-						expect{acl.filter!}.to raise_error Acl::DeniedHostError, "given IP Address is not allowed length."
-					end
-
-					it "will deny with 100.127.255.255" do
-						acl = Acl::Acl.new "100.127.255.255", ["COM"]
-						expect{acl.filter!}.to raise_error Acl::DeniedHostError, "given IP Address is not allowed length."
-					end
-
-					it "will deny with 100.96.64.32" do
-						acl = Acl::Acl.new "100.96.64.32", ["COM"]
-						expect{acl.filter!}.to raise_error Acl::DeniedHostError, "given IP Address is not allowed length."
-					end
-				end
-
-				context "IPv6 loop-back" do
-					it "will deny with ::1" do
-						acl = Acl::Acl.new "::1", ["COM"]
-						expect{acl.filter!}.to raise_error Acl::DeniedHostError, "given IP Address is not allowed length."
-					end
-				end
-
-				context "IPv6 unique local addresses" do
-					it "will deny with fc00:0000:0000:0000:0000:0000:0000:0000" do
-						acl = Acl::Acl.new "fc00:0000:0000:0000:0000:0000:0000:0000", ["COM"]
-						expect{acl.filter!}.to raise_error Acl::DeniedHostError, "given IP Address is not allowed length."
-					end
-
-					it "will deny with fc00:0000:0000:0000:0000:0000:0000:0001" do
-						acl = Acl::Acl.new "fc00:0000:0000:0000:0000:0000:0000:0001", ["COM"]
-						expect{acl.filter!}.to raise_error Acl::DeniedHostError, "given IP Address is not allowed length."
-					end
-
-					it "will deny with fdff:ffff:ffff:ffff:ffff:ffff:ffff:fffe" do
-						acl = Acl::Acl.new "fdff:ffff:ffff:ffff:ffff:ffff:ffff:fffe", ["COM"]
-						expect{acl.filter!}.to raise_error Acl::DeniedHostError, "given IP Address is not allowed length."
-					end
-
-					it "will deny with fdff:ffff:ffff:ffff:ffff:ffff:ffff:ffff" do
-						acl = Acl::Acl.new "fdff:ffff:ffff:ffff:ffff:ffff:ffff:ffff", ["COM"]
-						expect{acl.filter!}.to raise_error Acl::DeniedHostError, "given IP Address is not allowed length."
-					end
-
-					it "will deny with fd00:cafe:cafe:cafe:cafe:cafe:cafe:cafe (No reason)" do
-						acl = Acl::Acl.new "fd00:cafe:cafe:cafe:cafe:cafe:cafe:cafe", ["COM"]
-						expect{acl.filter!}.to raise_error Acl::DeniedHostError, "given IP Address is not allowed length."
-					end
-				end
-
-				context "IPv6 link local addresses" do
-					it "will deny with fe80:0000:0000:0000:0000:0000:0000:0000" do
-						acl = Acl::Acl.new "fe80:0000:0000:0000:0000:0000:0000:0000", ["COM"]
-						expect{acl.filter!}.to raise_error Acl::DeniedHostError, "given IP Address is not allowed length."
-					end
-
-					it "will deny with fe80:0000:0000:0000:0000:0000:0000:0001" do
-						acl = Acl::Acl.new "fe80:0000:0000:0000:0000:0000:0000:0001", ["COM"]
-						expect{acl.filter!}.to raise_error Acl::DeniedHostError, "given IP Address is not allowed length."
-					end
-
-					it "will deny with febf:ffff:ffff:ffff:ffff:ffff:ffff:fffe" do
-						acl = Acl::Acl.new "febf:ffff:ffff:ffff:ffff:ffff:ffff:fffe", ["COM"]
-						expect{acl.filter!}.to raise_error Acl::DeniedHostError, "given IP Address is not allowed length."
-					end
-
-					it "will deny with febf:ffff:ffff:ffff:ffff:ffff:ffff:ffff" do
-						acl = Acl::Acl.new "febf:ffff:ffff:ffff:ffff:ffff:ffff:ffff", ["COM"]
-						expect{acl.filter!}.to raise_error Acl::DeniedHostError, "given IP Address is not allowed length."
-					end
-
-					it "will deny with febf:beef:beef:beef:beef:beef:beef:beef (No reason)" do
-						acl = Acl::Acl.new "febf:beef:beef:beef:beef:beef:beef:beef", ["COM"]
-						expect{acl.filter!}.to raise_error Acl::DeniedHostError, "given IP Address is not allowed length."
-					end
-				end
-
-				context "IPv6 multicast address on interface local" do
-					it "will deny with ff01::1" do
-						acl = Acl::Acl.new "ff01::1", ["COM"]
-						expect{acl.filter!}.to raise_error Acl::DeniedHostError, "given IP Address is not allowed length."
-					end
-
-					it "will deny with ff01:0000:0000:0000:0000:0000:0000:0001" do
-						acl = Acl::Acl.new "ff01:0000:0000:0000:0000:0000:0000:0001", ["COM"]
-						expect{acl.filter!}.to raise_error Acl::DeniedHostError, "given IP Address is not allowed length."
-					end
-				end
-
-				context "IPv6 multicast address on link local" do
-					it "will deny with ff02::1" do
-						acl = Acl::Acl.new "ff01::1", ["COM"]
-						expect{acl.filter!}.to raise_error Acl::DeniedHostError, "given IP Address is not allowed length."
-					end
-
-					it "will deny with ff02:0000:0000:0000:0000:0000:0000:0001" do
-						acl = Acl::Acl.new "ff01:0000:0000:0000:0000:0000:0000:0001", ["COM"]
-						expect{acl.filter!}.to raise_error Acl::DeniedHostError, "given IP Address is not allowed length."
+				context "deny cases by domain which is not include TLD list." do
+					it "will deny with example.com with excluding com domain list" do
+						acl = Acl::Acl.new "example.com", ["ORG", "NET"]
+						expect{acl.filter!}.to raise_error Acl::DeniedHostError, "given TLD of hostname is not correct."
 					end
 				end
 			end
 
-			context "deny cases by correct domains" do
-				it "will deny with not exsits top level domain" do
-					acl = Acl::Acl.new "minecraft.example.com.hogehoge", ["COM"]
-					expect{acl.filter!}.to raise_error Acl::DeniedHostError, "given TLD of hostname is not correct."
+			context "allow cases" do
+				context "allow hostname" do
+					it "will allow example.com" do
+						acl = Acl::Acl.new "example.com", ["COM"]
+						expect{acl.filter!}.not_to raise_error
+					end
 				end
 
-				it "will deny with .local domain" do
-					acl = Acl::Acl.new "example.local", ["COM"]
-					expect{acl.filter!}.to raise_error Acl::DeniedHostError, "given TLD of hostname is not correct."
-				end
-
-				it "will deny with localhost domain" do
-					acl = Acl::Acl.new "localhost", ["COM"]
-					expect{acl.filter!}.to raise_error Acl::DeniedHostError, "given TLD of hostname is not correct."
-				end
-			end
-
-			context "deny cases by bad domain names" do
-				it "will deny with hogehoge-pc domain" do
-					# Can not parse as hostname and IPaddress.
-					acl = Acl::Acl.new "hogehoge-pc", ["COM"]
-					expect{acl.filter!}.to raise_error ArgumentError
+				context "allow IP addresses" do
+					it "will allow 203.0.113.1" do
+						# This address is length of RFC6890 TEST-NET-2 203.0.113.0/24
+						acl = Acl::Acl.new "203.0.113.1", ["COM"]
+						expect{acl.filter!}.not_to raise_error
+					end
 				end
 			end
 		end

--- a/spec/lib/acl/acl_spec.rb
+++ b/spec/lib/acl/acl_spec.rb
@@ -420,3 +420,17 @@ RSpec.describe Acl::Acl do
 		end
 	end
 end
+
+RSpec.describe Acl::DeniedHostError do
+	it "raise error" do
+		expect{raise Acl::DeniedHostError}.to raise_error Acl::DeniedHostError
+	end
+
+	it "raise error with default message." do
+		expect{raise Acl::DeniedHostError}.to raise_error Acl::DeniedHostError, "Request to this host is not allowed."
+	end
+
+	it "raise error with custom message." do
+		expect{raise Acl::DeniedHostError, "foo"}.to raise_error Acl::DeniedHostError, "foo"
+	end
+end

--- a/spec/lib/acl/acl_spec.rb
+++ b/spec/lib/acl/acl_spec.rb
@@ -49,7 +49,8 @@ RSpec.describe Acl::Acl do
 						expect{Acl::Acl.new "example.com", []}.to raise_error ArgumentError
 					end
 
-					it "raise error by tld_list is Array of numbers." do
+					xit "raise error by tld_list is Array of numbers." do
+						# Issue #53
 						expect{Acl::Acl.new "example.com", [1,2,3]}.to raise_error ArgumentError
 					end
 				end

--- a/spec/lib/acl/acl_spec.rb
+++ b/spec/lib/acl/acl_spec.rb
@@ -6,4 +6,295 @@ RSpec.describe Acl::Acl do
 		acl = Acl::Acl.new "", App::Application.config.tld_list["TLD"]
 		expect(acl.class).to eq(Acl::Acl)
 	end
+
+	describe "methods" do
+		describe "initialize()" do
+			
+		end
+
+		describe "filter!" do
+			context "deny cases by ip address" do
+				context "IPv4 local addresses" do
+					context "192.168.x.x" do
+						it "will deny with 192.168.0.0" do
+							acl = Acl::Acl.new "192.168.0.0", ["COM"]
+							expect{acl.filter!}.to raise_error Acl::DeniedHostError, "given IP Address is not allowed length."
+						end
+
+						it "will deny with 192.168.0.1" do
+							acl = Acl::Acl.new "192.168.0.1", ["COM"]
+							expect{acl.filter!}.to raise_error Acl::DeniedHostError, "given IP Address is not allowed length."
+						end
+
+						it "will deny with 192.168.255.254" do
+							acl = Acl::Acl.new "192.168.255.254", ["COM"]
+							expect{acl.filter!}.to raise_error Acl::DeniedHostError, "given IP Address is not allowed length."
+						end
+
+						it "will deny with 192.168.255.255" do
+							acl = Acl::Acl.new "192.168.255.255", ["COM"]
+							expect{acl.filter!}.to raise_error Acl::DeniedHostError, "given IP Address is not allowed length."
+						end
+
+						it "will deny with 192.168.24.10 (No reason)" do
+							acl = Acl::Acl.new "192.168.24.10", ["COM"]
+							expect{acl.filter!}.to raise_error Acl::DeniedHostError, "given IP Address is not allowed length."
+						end
+					end
+
+					context "172.16.x.x ~ 172.31.x.x" do
+						it "will deny with 172.16.0.0" do
+							acl = Acl::Acl.new "172.16.0.0", ["COM"]
+							expect{acl.filter!}.to raise_error Acl::DeniedHostError, "given IP Address is not allowed length."
+						end
+
+						it "will deny with 172.16.0.1" do
+							acl = Acl::Acl.new "172.16.0.1", ["COM"]
+							expect{acl.filter!}.to raise_error Acl::DeniedHostError, "given IP Address is not allowed length."
+						end
+
+						it "will deny with 172.31.255.254" do
+							acl = Acl::Acl.new "172.31.255.254", ["COM"]
+							expect{acl.filter!}.to raise_error Acl::DeniedHostError, "given IP Address is not allowed length."
+						end
+
+						it "will deny with 172.31.255.255" do
+							acl = Acl::Acl.new "172.31.255.255", ["COM"]
+							expect{acl.filter!}.to raise_error Acl::DeniedHostError, "given IP Address is not allowed length."
+						end
+
+						it "will deny with 172.24.1.24 (No reason)" do
+							acl = Acl::Acl.new "172.24.1.24", ["COM"]
+							expect{acl.filter!}.to raise_error Acl::DeniedHostError, "given IP Address is not allowed length."
+						end
+					end
+
+					context "10.x.x.x" do
+						it "will deny with 10.0.0.0" do
+							acl = Acl::Acl.new "10.0.0.0", ["COM"]
+							expect{acl.filter!}.to raise_error Acl::DeniedHostError, "given IP Address is not allowed length."
+						end
+
+						it "will deny with 10.0.0.1" do
+							acl = Acl::Acl.new "10.0.0.1", ["COM"]
+							expect{acl.filter!}.to raise_error Acl::DeniedHostError, "given IP Address is not allowed length."
+						end
+
+						it "will deny with 10.255.255.254" do
+							acl = Acl::Acl.new "10.255.255.254", ["COM"]
+							expect{acl.filter!}.to raise_error Acl::DeniedHostError, "given IP Address is not allowed length."
+						end
+
+						it "will deny with 10.255.255.255" do
+							acl = Acl::Acl.new "10.255.255.255", ["COM"]
+							expect{acl.filter!}.to raise_error Acl::DeniedHostError, "given IP Address is not allowed length."
+						end
+
+						it "will deny with 10.10.192.31 (No reason)" do
+							acl = Acl::Acl.new "10.10.192.31", ["COM"]
+							expect{acl.filter!}.to raise_error Acl::DeniedHostError, "given IP Address is not allowed length."
+						end
+					end
+				end
+
+				context "IPv4 broadcast address" do
+					it "will deny with 255.255.255.255" do
+						acl = Acl::Acl.new "255.255.255.255", ["COM"]
+						expect{acl.filter!}.to raise_error Acl::DeniedHostError, "given IP Address is not allowed length."
+					end
+				end
+
+				context "IPv4 loop-back addresses" do
+					it "will deny with 127.0.0.0" do
+						acl = Acl::Acl.new "127.0.0.0", ["COM"]
+						expect{acl.filter!}.to raise_error Acl::DeniedHostError, "given IP Address is not allowed length."
+					end
+
+					it "will deny with 127.0.0.1" do
+						acl = Acl::Acl.new "127.0.0.1", ["COM"]
+						expect{acl.filter!}.to raise_error Acl::DeniedHostError, "given IP Address is not allowed length."
+					end
+
+					it "will deny with 127.255.255.254" do
+						acl = Acl::Acl.new "127.255.255.254", ["COM"]
+						expect{acl.filter!}.to raise_error Acl::DeniedHostError, "given IP Address is not allowed length."
+					end
+
+					it "will deny with 127.255.255.255" do
+						acl = Acl::Acl.new "127.255.255.255", ["COM"]
+						expect{acl.filter!}.to raise_error Acl::DeniedHostError, "given IP Address is not allowed length."
+					end
+
+					it "will deny with 127.0.0.53 (No reason)" do
+						acl = Acl::Acl.new "127.0.0.53", ["COM"]
+						expect{acl.filter!}.to raise_error Acl::DeniedHostError, "given IP Address is not allowed length."
+					end
+				end
+
+				context "IPv4 link-local address" do
+					it "will deny with 169.254.0.0" do
+						acl = Acl::Acl.new "169.254.0.0", ["COM"]
+						expect{acl.filter!}.to raise_error Acl::DeniedHostError, "given IP Address is not allowed length."
+					end
+
+					it "will deny with 169.254.0.1" do
+						acl = Acl::Acl.new "169.254.0.1", ["COM"]
+						expect{acl.filter!}.to raise_error Acl::DeniedHostError, "given IP Address is not allowed length."
+					end
+
+					it "will deny with 169.254.255.254" do
+						acl = Acl::Acl.new "169.254.255.254", ["COM"]
+						expect{acl.filter!}.to raise_error Acl::DeniedHostError, "given IP Address is not allowed length."
+					end
+
+					it "will deny with 169.254.255.255" do
+						acl = Acl::Acl.new "169.254.255.255", ["COM"]
+						expect{acl.filter!}.to raise_error Acl::DeniedHostError, "given IP Address is not allowed length."
+					end
+
+					it "will deny with 169.254.1.10 (No reason)" do
+						acl = Acl::Acl.new "169.254.1.10", ["COM"]
+						expect{acl.filter!}.to raise_error Acl::DeniedHostError, "given IP Address is not allowed length."
+					end
+				end
+
+				context "IPv4 shared address space" do
+					it "will deny with 100.64.0.0" do
+						acl = Acl::Acl.new "100.64.0.0", ["COM"]
+						expect{acl.filter!}.to raise_error Acl::DeniedHostError, "given IP Address is not allowed length."
+					end
+
+					it "will deny with 100.64.0.1" do
+						acl = Acl::Acl.new "100.64.0.1", ["COM"]
+						expect{acl.filter!}.to raise_error Acl::DeniedHostError, "given IP Address is not allowed length."
+					end
+
+					it "will deny with 100.127.255.254" do
+						acl = Acl::Acl.new "100.127.255.254", ["COM"]
+						expect{acl.filter!}.to raise_error Acl::DeniedHostError, "given IP Address is not allowed length."
+					end
+
+					it "will deny with 100.127.255.255" do
+						acl = Acl::Acl.new "100.127.255.255", ["COM"]
+						expect{acl.filter!}.to raise_error Acl::DeniedHostError, "given IP Address is not allowed length."
+					end
+
+					it "will deny with 100.96.64.32" do
+						acl = Acl::Acl.new "100.96.64.32", ["COM"]
+						expect{acl.filter!}.to raise_error Acl::DeniedHostError, "given IP Address is not allowed length."
+					end
+				end
+
+				context "IPv6 loop-back" do
+					it "will deny with ::1" do
+						acl = Acl::Acl.new "::1", ["COM"]
+						expect{acl.filter!}.to raise_error Acl::DeniedHostError, "given IP Address is not allowed length."
+					end
+				end
+
+				context "IPv6 unique local addresses" do
+					it "will deny with fc00:0000:0000:0000:0000:0000:0000:0000" do
+						acl = Acl::Acl.new "fc00:0000:0000:0000:0000:0000:0000:0000", ["COM"]
+						expect{acl.filter!}.to raise_error Acl::DeniedHostError, "given IP Address is not allowed length."
+					end
+
+					it "will deny with fc00:0000:0000:0000:0000:0000:0000:0001" do
+						acl = Acl::Acl.new "fc00:0000:0000:0000:0000:0000:0000:0001", ["COM"]
+						expect{acl.filter!}.to raise_error Acl::DeniedHostError, "given IP Address is not allowed length."
+					end
+
+					it "will deny with fdff:ffff:ffff:ffff:ffff:ffff:ffff:fffe" do
+						acl = Acl::Acl.new "fdff:ffff:ffff:ffff:ffff:ffff:ffff:fffe", ["COM"]
+						expect{acl.filter!}.to raise_error Acl::DeniedHostError, "given IP Address is not allowed length."
+					end
+
+					it "will deny with fdff:ffff:ffff:ffff:ffff:ffff:ffff:ffff" do
+						acl = Acl::Acl.new "fdff:ffff:ffff:ffff:ffff:ffff:ffff:ffff", ["COM"]
+						expect{acl.filter!}.to raise_error Acl::DeniedHostError, "given IP Address is not allowed length."
+					end
+
+					it "will deny with fd00:cafe:cafe:cafe:cafe:cafe:cafe:cafe (No reason)" do
+						acl = Acl::Acl.new "fd00:cafe:cafe:cafe:cafe:cafe:cafe:cafe", ["COM"]
+						expect{acl.filter!}.to raise_error Acl::DeniedHostError, "given IP Address is not allowed length."
+					end
+				end
+
+				context "IPv6 link local addresses" do
+					it "will deny with fe80:0000:0000:0000:0000:0000:0000:0000" do
+						acl = Acl::Acl.new "fe80:0000:0000:0000:0000:0000:0000:0000", ["COM"]
+						expect{acl.filter!}.to raise_error Acl::DeniedHostError, "given IP Address is not allowed length."
+					end
+
+					it "will deny with fe80:0000:0000:0000:0000:0000:0000:0001" do
+						acl = Acl::Acl.new "fe80:0000:0000:0000:0000:0000:0000:0001", ["COM"]
+						expect{acl.filter!}.to raise_error Acl::DeniedHostError, "given IP Address is not allowed length."
+					end
+
+					it "will deny with febf:ffff:ffff:ffff:ffff:ffff:ffff:fffe" do
+						acl = Acl::Acl.new "febf:ffff:ffff:ffff:ffff:ffff:ffff:fffe", ["COM"]
+						expect{acl.filter!}.to raise_error Acl::DeniedHostError, "given IP Address is not allowed length."
+					end
+
+					it "will deny with febf:ffff:ffff:ffff:ffff:ffff:ffff:ffff" do
+						acl = Acl::Acl.new "febf:ffff:ffff:ffff:ffff:ffff:ffff:ffff", ["COM"]
+						expect{acl.filter!}.to raise_error Acl::DeniedHostError, "given IP Address is not allowed length."
+					end
+
+					it "will deny with febf:beef:beef:beef:beef:beef:beef:beef (No reason)" do
+						acl = Acl::Acl.new "febf:beef:beef:beef:beef:beef:beef:beef", ["COM"]
+						expect{acl.filter!}.to raise_error Acl::DeniedHostError, "given IP Address is not allowed length."
+					end
+				end
+
+				context "IPv6 multicast address on interface local" do
+					it "will deny with ff01::1" do
+						acl = Acl::Acl.new "ff01::1", ["COM"]
+						expect{acl.filter!}.to raise_error Acl::DeniedHostError, "given IP Address is not allowed length."
+					end
+
+					it "will deny with ff01:0000:0000:0000:0000:0000:0000:0001" do
+						acl = Acl::Acl.new "ff01:0000:0000:0000:0000:0000:0000:0001", ["COM"]
+						expect{acl.filter!}.to raise_error Acl::DeniedHostError, "given IP Address is not allowed length."
+					end
+				end
+
+				context "IPv6 multicast address on link local" do
+					it "will deny with ff02::1" do
+						acl = Acl::Acl.new "ff01::1", ["COM"]
+						expect{acl.filter!}.to raise_error Acl::DeniedHostError, "given IP Address is not allowed length."
+					end
+
+					it "will deny with ff02:0000:0000:0000:0000:0000:0000:0001" do
+						acl = Acl::Acl.new "ff01:0000:0000:0000:0000:0000:0000:0001", ["COM"]
+						expect{acl.filter!}.to raise_error Acl::DeniedHostError, "given IP Address is not allowed length."
+					end
+				end
+			end
+
+			context "deny cases by correct domains" do
+				it "will deny with not exsits top level domain" do
+					acl = Acl::Acl.new "minecraft.example.com.hogehoge", ["COM"]
+					expect{acl.filter!}.to raise_error Acl::DeniedHostError, "given TLD of hostname is not correct."
+				end
+
+				it "will deny with .local domain" do
+					acl = Acl::Acl.new "example.local", ["COM"]
+					expect{acl.filter!}.to raise_error Acl::DeniedHostError, "given TLD of hostname is not correct."
+				end
+
+				it "will deny with localhost domain" do
+					acl = Acl::Acl.new "localhost", ["COM"]
+					expect{acl.filter!}.to raise_error Acl::DeniedHostError, "given TLD of hostname is not correct."
+				end
+			end
+
+			context "deny cases by bad domain names" do
+				it "will deny with hogehoge-pc domain" do
+					# Can not parse as hostname and IPaddress.
+					acl = Acl::Acl.new "hogehoge-pc", ["COM"]
+					expect{acl.filter!}.to raise_error ArgumentError
+				end
+			end
+		end
+	end
 end

--- a/spec/lib/acl/acl_spec.rb
+++ b/spec/lib/acl/acl_spec.rb
@@ -3,7 +3,7 @@ require './lib/acl/acl.rb'
 
 RSpec.describe Acl::Acl do
 	it "is object of Acl::Acl class" do
-		acl = Acl::Acl.new ""
+		acl = Acl::Acl.new "", App::Application.config.tld_list["TLD"]
 		expect(acl.class).to eq(Acl::Acl)
 	end
 end

--- a/spec/requests/api/v1/servers/status_spec.rb
+++ b/spec/requests/api/v1/servers/status_spec.rb
@@ -17,7 +17,7 @@ RSpec.describe "Api::V1::Servers::Statuses", type: :request do
 
 								json = JSON.parse response.body
 								expect(response).to have_http_status 400
-								expect(json["message"]).to eq "Request to this host is not allowed."
+								expect(json["message"]).to eq "given IP Address is not allowed length."
 							end
 
 							it "will deny with 192.168.0.1" do
@@ -25,7 +25,7 @@ RSpec.describe "Api::V1::Servers::Statuses", type: :request do
 
 								json = JSON.parse response.body
 								expect(response).to have_http_status 400
-								expect(json["message"]).to eq "Request to this host is not allowed."
+								expect(json["message"]).to eq "given IP Address is not allowed length."
 							end
 
 							it "will deny with 192.168.255.254" do
@@ -33,7 +33,7 @@ RSpec.describe "Api::V1::Servers::Statuses", type: :request do
 
 								json = JSON.parse response.body
 								expect(response).to have_http_status 400
-								expect(json["message"]).to eq "Request to this host is not allowed."
+								expect(json["message"]).to eq "given IP Address is not allowed length."
 							end
 
 							it "will deny with 192.168.255.255" do
@@ -41,7 +41,7 @@ RSpec.describe "Api::V1::Servers::Statuses", type: :request do
 
 								json = JSON.parse response.body
 								expect(response).to have_http_status 400
-								expect(json["message"]).to eq "Request to this host is not allowed."
+								expect(json["message"]).to eq "given IP Address is not allowed length."
 							end
 
 							it "will deny with 192.168.24.10 (No reason)" do
@@ -49,7 +49,7 @@ RSpec.describe "Api::V1::Servers::Statuses", type: :request do
 
 								json = JSON.parse response.body
 								expect(response).to have_http_status 400
-								expect(json["message"]).to eq "Request to this host is not allowed."
+								expect(json["message"]).to eq "given IP Address is not allowed length."
 							end
 						end
 
@@ -59,7 +59,7 @@ RSpec.describe "Api::V1::Servers::Statuses", type: :request do
 
 								json = JSON.parse response.body
 								expect(response).to have_http_status 400
-								expect(json["message"]).to eq "Request to this host is not allowed."
+								expect(json["message"]).to eq "given IP Address is not allowed length."
 							end
 
 							it "will deny with 172.16.0.1" do
@@ -67,7 +67,7 @@ RSpec.describe "Api::V1::Servers::Statuses", type: :request do
 
 								json = JSON.parse response.body
 								expect(response).to have_http_status 400
-								expect(json["message"]).to eq "Request to this host is not allowed."
+								expect(json["message"]).to eq "given IP Address is not allowed length."
 							end
 
 							it "will deny with 172.31.255.254" do
@@ -75,7 +75,7 @@ RSpec.describe "Api::V1::Servers::Statuses", type: :request do
 
 								json = JSON.parse response.body
 								expect(response).to have_http_status 400
-								expect(json["message"]).to eq "Request to this host is not allowed."
+								expect(json["message"]).to eq "given IP Address is not allowed length."
 							end
 
 							it "will deny with 172.31.255.255" do
@@ -83,7 +83,7 @@ RSpec.describe "Api::V1::Servers::Statuses", type: :request do
 
 								json = JSON.parse response.body
 								expect(response).to have_http_status 400
-								expect(json["message"]).to eq "Request to this host is not allowed."
+								expect(json["message"]).to eq "given IP Address is not allowed length."
 							end
 
 							it "will deny with 172.24.1.24 (No reason)" do
@@ -91,7 +91,7 @@ RSpec.describe "Api::V1::Servers::Statuses", type: :request do
 
 								json = JSON.parse response.body
 								expect(response).to have_http_status 400
-								expect(json["message"]).to eq "Request to this host is not allowed."
+								expect(json["message"]).to eq "given IP Address is not allowed length."
 							end
 						end
 
@@ -101,7 +101,7 @@ RSpec.describe "Api::V1::Servers::Statuses", type: :request do
 
 								json = JSON.parse response.body
 								expect(response).to have_http_status 400
-								expect(json["message"]).to eq "Request to this host is not allowed."
+								expect(json["message"]).to eq "given IP Address is not allowed length."
 							end
 
 							it "will deny with 10.0.0.1" do
@@ -109,7 +109,7 @@ RSpec.describe "Api::V1::Servers::Statuses", type: :request do
 
 								json = JSON.parse response.body
 								expect(response).to have_http_status 400
-								expect(json["message"]).to eq "Request to this host is not allowed."
+								expect(json["message"]).to eq "given IP Address is not allowed length."
 							end
 
 							it "will deny with 10.255.255.254" do
@@ -117,7 +117,7 @@ RSpec.describe "Api::V1::Servers::Statuses", type: :request do
 
 								json = JSON.parse response.body
 								expect(response).to have_http_status 400
-								expect(json["message"]).to eq "Request to this host is not allowed."
+								expect(json["message"]).to eq "given IP Address is not allowed length."
 							end
 
 							it "will deny with 10.255.255.255" do
@@ -125,7 +125,7 @@ RSpec.describe "Api::V1::Servers::Statuses", type: :request do
 
 								json = JSON.parse response.body
 								expect(response).to have_http_status 400
-								expect(json["message"]).to eq "Request to this host is not allowed."
+								expect(json["message"]).to eq "given IP Address is not allowed length."
 							end
 
 							it "will deny with 10.10.192.31 (No reason)" do
@@ -133,7 +133,7 @@ RSpec.describe "Api::V1::Servers::Statuses", type: :request do
 
 								json = JSON.parse response.body
 								expect(response).to have_http_status 400
-								expect(json["message"]).to eq "Request to this host is not allowed."
+								expect(json["message"]).to eq "given IP Address is not allowed length."
 							end
 						end
 					end
@@ -144,7 +144,7 @@ RSpec.describe "Api::V1::Servers::Statuses", type: :request do
 
 							json = JSON.parse response.body
 							expect(response).to have_http_status 400
-							expect(json["message"]).to eq "Request to this host is not allowed."
+							expect(json["message"]).to eq "given IP Address is not allowed length."
 						end
 					end
 
@@ -154,7 +154,7 @@ RSpec.describe "Api::V1::Servers::Statuses", type: :request do
 
 							json = JSON.parse response.body
 							expect(response).to have_http_status 400
-							expect(json["message"]).to eq "Request to this host is not allowed."
+							expect(json["message"]).to eq "given IP Address is not allowed length."
 						end
 
 						it "will deny with 127.0.0.1" do
@@ -162,7 +162,7 @@ RSpec.describe "Api::V1::Servers::Statuses", type: :request do
 
 							json = JSON.parse response.body
 							expect(response).to have_http_status 400
-							expect(json["message"]).to eq "Request to this host is not allowed."
+							expect(json["message"]).to eq "given IP Address is not allowed length."
 						end
 
 						it "will deny with 127.255.255.254" do
@@ -170,7 +170,7 @@ RSpec.describe "Api::V1::Servers::Statuses", type: :request do
 
 							json = JSON.parse response.body
 							expect(response).to have_http_status 400
-							expect(json["message"]).to eq "Request to this host is not allowed."
+							expect(json["message"]).to eq "given IP Address is not allowed length."
 						end
 
 						it "will deny with 127.255.255.255" do
@@ -178,7 +178,7 @@ RSpec.describe "Api::V1::Servers::Statuses", type: :request do
 
 							json = JSON.parse response.body
 							expect(response).to have_http_status 400
-							expect(json["message"]).to eq "Request to this host is not allowed."
+							expect(json["message"]).to eq "given IP Address is not allowed length."
 						end
 
 						it "will deny with 127.0.0.53 (No reason)" do
@@ -186,7 +186,7 @@ RSpec.describe "Api::V1::Servers::Statuses", type: :request do
 
 							json = JSON.parse response.body
 							expect(response).to have_http_status 400
-							expect(json["message"]).to eq "Request to this host is not allowed."
+							expect(json["message"]).to eq "given IP Address is not allowed length."
 						end
 					end
 
@@ -196,7 +196,7 @@ RSpec.describe "Api::V1::Servers::Statuses", type: :request do
 
 							json = JSON.parse response.body
 							expect(response).to have_http_status 400
-							expect(json["message"]).to eq "Request to this host is not allowed."
+							expect(json["message"]).to eq "given IP Address is not allowed length."
 						end
 
 						it "will deny with 169.254.0.1" do
@@ -204,7 +204,7 @@ RSpec.describe "Api::V1::Servers::Statuses", type: :request do
 
 							json = JSON.parse response.body
 							expect(response).to have_http_status 400
-							expect(json["message"]).to eq "Request to this host is not allowed."
+							expect(json["message"]).to eq "given IP Address is not allowed length."
 						end
 
 						it "will deny with 169.254.255.254" do
@@ -212,7 +212,7 @@ RSpec.describe "Api::V1::Servers::Statuses", type: :request do
 
 							json = JSON.parse response.body
 							expect(response).to have_http_status 400
-							expect(json["message"]).to eq "Request to this host is not allowed."
+							expect(json["message"]).to eq "given IP Address is not allowed length."
 						end
 
 						it "will deny with 169.254.255.255" do
@@ -220,7 +220,7 @@ RSpec.describe "Api::V1::Servers::Statuses", type: :request do
 
 							json = JSON.parse response.body
 							expect(response).to have_http_status 400
-							expect(json["message"]).to eq "Request to this host is not allowed."
+							expect(json["message"]).to eq "given IP Address is not allowed length."
 						end
 
 						it "will deny with 169.254.1.10 (No reason)" do
@@ -228,7 +228,7 @@ RSpec.describe "Api::V1::Servers::Statuses", type: :request do
 
 							json = JSON.parse response.body
 							expect(response).to have_http_status 400
-							expect(json["message"]).to eq "Request to this host is not allowed."
+							expect(json["message"]).to eq "given IP Address is not allowed length."
 						end
 					end
 
@@ -238,7 +238,7 @@ RSpec.describe "Api::V1::Servers::Statuses", type: :request do
 
 							json = JSON.parse response.body
 							expect(response).to have_http_status 400
-							expect(json["message"]).to eq "Request to this host is not allowed."
+							expect(json["message"]).to eq "given IP Address is not allowed length."
 						end
 
 						it "will deny with 100.64.0.1" do
@@ -246,7 +246,7 @@ RSpec.describe "Api::V1::Servers::Statuses", type: :request do
 
 							json = JSON.parse response.body
 							expect(response).to have_http_status 400
-							expect(json["message"]).to eq "Request to this host is not allowed."
+							expect(json["message"]).to eq "given IP Address is not allowed length."
 						end
 
 						it "will deny with 100.127.255.254" do
@@ -254,7 +254,7 @@ RSpec.describe "Api::V1::Servers::Statuses", type: :request do
 
 							json = JSON.parse response.body
 							expect(response).to have_http_status 400
-							expect(json["message"]).to eq "Request to this host is not allowed."
+							expect(json["message"]).to eq "given IP Address is not allowed length."
 						end
 
 						it "will deny with 100.127.255.255" do
@@ -262,7 +262,7 @@ RSpec.describe "Api::V1::Servers::Statuses", type: :request do
 
 							json = JSON.parse response.body
 							expect(response).to have_http_status 400
-							expect(json["message"]).to eq "Request to this host is not allowed."
+							expect(json["message"]).to eq "given IP Address is not allowed length."
 						end
 
 						it "will deny with 100.96.64.32" do
@@ -270,7 +270,7 @@ RSpec.describe "Api::V1::Servers::Statuses", type: :request do
 
 							json = JSON.parse response.body
 							expect(response).to have_http_status 400
-							expect(json["message"]).to eq "Request to this host is not allowed."
+							expect(json["message"]).to eq "given IP Address is not allowed length."
 						end
 					end
 
@@ -280,7 +280,7 @@ RSpec.describe "Api::V1::Servers::Statuses", type: :request do
 
 							json = JSON.parse response.body
 							expect(response).to have_http_status 400
-							expect(json["message"]).to eq "Request to this host is not allowed."
+							expect(json["message"]).to eq "given IP Address is not allowed length."
 						end
 					end
 
@@ -290,7 +290,7 @@ RSpec.describe "Api::V1::Servers::Statuses", type: :request do
 
 							json = JSON.parse response.body
 							expect(response).to have_http_status 400
-							expect(json["message"]).to eq "Request to this host is not allowed."
+							expect(json["message"]).to eq "given IP Address is not allowed length."
 						end
 
 						it "will deny with fc00:0000:0000:0000:0000:0000:0000:0001" do
@@ -298,7 +298,7 @@ RSpec.describe "Api::V1::Servers::Statuses", type: :request do
 
 							json = JSON.parse response.body
 							expect(response).to have_http_status 400
-							expect(json["message"]).to eq "Request to this host is not allowed."
+							expect(json["message"]).to eq "given IP Address is not allowed length."
 						end
 
 						it "will deny with fdff:ffff:ffff:ffff:ffff:ffff:ffff:fffe" do
@@ -306,7 +306,7 @@ RSpec.describe "Api::V1::Servers::Statuses", type: :request do
 
 							json = JSON.parse response.body
 							expect(response).to have_http_status 400
-							expect(json["message"]).to eq "Request to this host is not allowed."
+							expect(json["message"]).to eq "given IP Address is not allowed length."
 						end
 
 						it "will deny with fdff:ffff:ffff:ffff:ffff:ffff:ffff:ffff" do
@@ -314,7 +314,7 @@ RSpec.describe "Api::V1::Servers::Statuses", type: :request do
 
 							json = JSON.parse response.body
 							expect(response).to have_http_status 400
-							expect(json["message"]).to eq "Request to this host is not allowed."
+							expect(json["message"]).to eq "given IP Address is not allowed length."
 						end
 
 						it "will deny with fd00:cafe:cafe:cafe:cafe:cafe:cafe:cafe (No reason)" do
@@ -322,7 +322,7 @@ RSpec.describe "Api::V1::Servers::Statuses", type: :request do
 
 							json = JSON.parse response.body
 							expect(response).to have_http_status 400
-							expect(json["message"]).to eq "Request to this host is not allowed."
+							expect(json["message"]).to eq "given IP Address is not allowed length."
 						end
 					end
 
@@ -332,7 +332,7 @@ RSpec.describe "Api::V1::Servers::Statuses", type: :request do
 
 							json = JSON.parse response.body
 							expect(response).to have_http_status 400
-							expect(json["message"]).to eq "Request to this host is not allowed."
+							expect(json["message"]).to eq "given IP Address is not allowed length."
 						end
 
 						it "will deny with fe80:0000:0000:0000:0000:0000:0000:0001" do
@@ -340,7 +340,7 @@ RSpec.describe "Api::V1::Servers::Statuses", type: :request do
 
 							json = JSON.parse response.body
 							expect(response).to have_http_status 400
-							expect(json["message"]).to eq "Request to this host is not allowed."
+							expect(json["message"]).to eq "given IP Address is not allowed length."
 						end
 
 						it "will deny with febf:ffff:ffff:ffff:ffff:ffff:ffff:fffe" do
@@ -348,7 +348,7 @@ RSpec.describe "Api::V1::Servers::Statuses", type: :request do
 
 							json = JSON.parse response.body
 							expect(response).to have_http_status 400
-							expect(json["message"]).to eq "Request to this host is not allowed."
+							expect(json["message"]).to eq "given IP Address is not allowed length."
 						end
 
 						it "will deny with febf:ffff:ffff:ffff:ffff:ffff:ffff:ffff" do
@@ -356,7 +356,7 @@ RSpec.describe "Api::V1::Servers::Statuses", type: :request do
 
 							json = JSON.parse response.body
 							expect(response).to have_http_status 400
-							expect(json["message"]).to eq "Request to this host is not allowed."
+							expect(json["message"]).to eq "given IP Address is not allowed length."
 						end
 
 						it "will deny with febf:beef:beef:beef:beef:beef:beef:beef (No reason)" do
@@ -364,7 +364,7 @@ RSpec.describe "Api::V1::Servers::Statuses", type: :request do
 
 							json = JSON.parse response.body
 							expect(response).to have_http_status 400
-							expect(json["message"]).to eq "Request to this host is not allowed."
+							expect(json["message"]).to eq "given IP Address is not allowed length."
 						end
 					end
 
@@ -374,7 +374,7 @@ RSpec.describe "Api::V1::Servers::Statuses", type: :request do
 
 							json = JSON.parse response.body
 							expect(response).to have_http_status 400
-							expect(json["message"]).to eq "Request to this host is not allowed."
+							expect(json["message"]).to eq "given IP Address is not allowed length."
 						end
 
 						it "will deny with ff01:0000:0000:0000:0000:0000:0000:0001" do
@@ -382,7 +382,7 @@ RSpec.describe "Api::V1::Servers::Statuses", type: :request do
 
 							json = JSON.parse response.body
 							expect(response).to have_http_status 400
-							expect(json["message"]).to eq "Request to this host is not allowed."
+							expect(json["message"]).to eq "given IP Address is not allowed length."
 						end
 					end
 
@@ -392,7 +392,7 @@ RSpec.describe "Api::V1::Servers::Statuses", type: :request do
 
 							json = JSON.parse response.body
 							expect(response).to have_http_status 400
-							expect(json["message"]).to eq "Request to this host is not allowed."
+							expect(json["message"]).to eq "given IP Address is not allowed length."
 						end
 
 						it "will deny with ff02:0000:0000:0000:0000:0000:0000:0001" do
@@ -400,7 +400,7 @@ RSpec.describe "Api::V1::Servers::Statuses", type: :request do
 
 							json = JSON.parse response.body
 							expect(response).to have_http_status 400
-							expect(json["message"]).to eq "Request to this host is not allowed."
+							expect(json["message"]).to eq "given IP Address is not allowed length."
 						end
 					end
 				end

--- a/spec/requests/api/v1/servers/status_spec.rb
+++ b/spec/requests/api/v1/servers/status_spec.rb
@@ -10,147 +10,17 @@ RSpec.describe "Api::V1::Servers::Statuses", type: :request do
 		context "parameters" do
 			context "host" do
 				context "deny cases by ip address" do
-					context "IPv4 local addresses" do
-						context "192.168.x.x" do
-							it "will deny with 192.168.0.0" do
-								get api_v1_servers_status_index_path params: {host: "192.168.0.0"}
-
-								json = JSON.parse response.body
-								expect(response).to have_http_status 400
-								expect(json["message"]).to eq "given IP Address is not allowed length."
-							end
-
-							it "will deny with 192.168.0.1" do
-								get api_v1_servers_status_index_path params: {host: "192.168.0.1"}
-
-								json = JSON.parse response.body
-								expect(response).to have_http_status 400
-								expect(json["message"]).to eq "given IP Address is not allowed length."
-							end
-
-							it "will deny with 192.168.255.254" do
-								get api_v1_servers_status_index_path params: {host: "192.168.255.254"}
-
-								json = JSON.parse response.body
-								expect(response).to have_http_status 400
-								expect(json["message"]).to eq "given IP Address is not allowed length."
-							end
-
-							it "will deny with 192.168.255.255" do
-								get api_v1_servers_status_index_path params: {host: "192.168.255.255"}
-
-								json = JSON.parse response.body
-								expect(response).to have_http_status 400
-								expect(json["message"]).to eq "given IP Address is not allowed length."
-							end
-
-							it "will deny with 192.168.24.10 (No reason)" do
-								get api_v1_servers_status_index_path params: {host: "192.168.24.10"}
-
-								json = JSON.parse response.body
-								expect(response).to have_http_status 400
-								expect(json["message"]).to eq "given IP Address is not allowed length."
-							end
-						end
-
-						context "172.16.x.x ~ 172.31.x.x" do
-							it "will deny with 172.16.0.0" do
-								get api_v1_servers_status_index_path params: {host: "172.16.0.0"}
-
-								json = JSON.parse response.body
-								expect(response).to have_http_status 400
-								expect(json["message"]).to eq "given IP Address is not allowed length."
-							end
-
-							it "will deny with 172.16.0.1" do
-								get api_v1_servers_status_index_path params: {host: "172.16.0.1"}
-
-								json = JSON.parse response.body
-								expect(response).to have_http_status 400
-								expect(json["message"]).to eq "given IP Address is not allowed length."
-							end
-
-							it "will deny with 172.31.255.254" do
-								get api_v1_servers_status_index_path params: {host: "172.31.255.254"}
-
-								json = JSON.parse response.body
-								expect(response).to have_http_status 400
-								expect(json["message"]).to eq "given IP Address is not allowed length."
-							end
-
-							it "will deny with 172.31.255.255" do
-								get api_v1_servers_status_index_path params: {host: "172.31.255.255"}
-
-								json = JSON.parse response.body
-								expect(response).to have_http_status 400
-								expect(json["message"]).to eq "given IP Address is not allowed length."
-							end
-
-							it "will deny with 172.24.1.24 (No reason)" do
-								get api_v1_servers_status_index_path params: {host: "172.24.1.24"}
-
-								json = JSON.parse response.body
-								expect(response).to have_http_status 400
-								expect(json["message"]).to eq "given IP Address is not allowed length."
-							end
-						end
-
-						context "10.x.x.x" do
-							it "will deny with 10.0.0.0" do
-								get api_v1_servers_status_index_path params: {host: "10.0.0.0"}
-
-								json = JSON.parse response.body
-								expect(response).to have_http_status 400
-								expect(json["message"]).to eq "given IP Address is not allowed length."
-							end
-
-							it "will deny with 10.0.0.1" do
-								get api_v1_servers_status_index_path params: {host: "10.0.0.1"}
-
-								json = JSON.parse response.body
-								expect(response).to have_http_status 400
-								expect(json["message"]).to eq "given IP Address is not allowed length."
-							end
-
-							it "will deny with 10.255.255.254" do
-								get api_v1_servers_status_index_path params: {host: "10.255.255.254"}
-
-								json = JSON.parse response.body
-								expect(response).to have_http_status 400
-								expect(json["message"]).to eq "given IP Address is not allowed length."
-							end
-
-							it "will deny with 10.255.255.255" do
-								get api_v1_servers_status_index_path params: {host: "10.255.255.255"}
-
-								json = JSON.parse response.body
-								expect(response).to have_http_status 400
-								expect(json["message"]).to eq "given IP Address is not allowed length."
-							end
-
-							it "will deny with 10.10.192.31 (No reason)" do
-								get api_v1_servers_status_index_path params: {host: "10.10.192.31"}
-
-								json = JSON.parse response.body
-								expect(response).to have_http_status 400
-								expect(json["message"]).to eq "given IP Address is not allowed length."
-							end
-						end
-					end
-
-					context "IPv4 broadcast address" do
-						it "will deny with 255.255.255.255" do
-							get api_v1_servers_status_index_path params: {host: "255.255.255.255"}
+					context "IPv4 addresses" do
+						it "will deny with 192.168.0.1" do
+							get api_v1_servers_status_index_path params: {host: "192.168.0.1"}
 
 							json = JSON.parse response.body
 							expect(response).to have_http_status 400
 							expect(json["message"]).to eq "given IP Address is not allowed length."
 						end
-					end
 
-					context "IPv4 loop-back addresses" do
-						it "will deny with 127.0.0.0" do
-							get api_v1_servers_status_index_path params: {host: "127.0.0.0"}
+						it "will deny with 255.255.255.255" do
+							get api_v1_servers_status_index_path params: {host: "255.255.255.255"}
 
 							json = JSON.parse response.body
 							expect(response).to have_http_status 400
@@ -164,117 +34,9 @@ RSpec.describe "Api::V1::Servers::Statuses", type: :request do
 							expect(response).to have_http_status 400
 							expect(json["message"]).to eq "given IP Address is not allowed length."
 						end
-
-						it "will deny with 127.255.255.254" do
-							get api_v1_servers_status_index_path params: {host: "127.255.255.254"}
-
-							json = JSON.parse response.body
-							expect(response).to have_http_status 400
-							expect(json["message"]).to eq "given IP Address is not allowed length."
-						end
-
-						it "will deny with 127.255.255.255" do
-							get api_v1_servers_status_index_path params: {host: "127.255.255.255"}
-
-							json = JSON.parse response.body
-							expect(response).to have_http_status 400
-							expect(json["message"]).to eq "given IP Address is not allowed length."
-						end
-
-						it "will deny with 127.0.0.53 (No reason)" do
-							get api_v1_servers_status_index_path params: {host: "127.0.0.53"}
-
-							json = JSON.parse response.body
-							expect(response).to have_http_status 400
-							expect(json["message"]).to eq "given IP Address is not allowed length."
-						end
 					end
 
-					context "IPv4 link-local address" do
-						it "will deny with 169.254.0.0" do
-							get api_v1_servers_status_index_path params: {host: "169.254.0.0"}
-
-							json = JSON.parse response.body
-							expect(response).to have_http_status 400
-							expect(json["message"]).to eq "given IP Address is not allowed length."
-						end
-
-						it "will deny with 169.254.0.1" do
-							get api_v1_servers_status_index_path params: {host: "169.254.0.1"}
-
-							json = JSON.parse response.body
-							expect(response).to have_http_status 400
-							expect(json["message"]).to eq "given IP Address is not allowed length."
-						end
-
-						it "will deny with 169.254.255.254" do
-							get api_v1_servers_status_index_path params: {host: "169.254.255.254"}
-
-							json = JSON.parse response.body
-							expect(response).to have_http_status 400
-							expect(json["message"]).to eq "given IP Address is not allowed length."
-						end
-
-						it "will deny with 169.254.255.255" do
-							get api_v1_servers_status_index_path params: {host: "169.254.255.255"}
-
-							json = JSON.parse response.body
-							expect(response).to have_http_status 400
-							expect(json["message"]).to eq "given IP Address is not allowed length."
-						end
-
-						it "will deny with 169.254.1.10 (No reason)" do
-							get api_v1_servers_status_index_path params: {host: "169.254.1.10"}
-
-							json = JSON.parse response.body
-							expect(response).to have_http_status 400
-							expect(json["message"]).to eq "given IP Address is not allowed length."
-						end
-					end
-
-					context "IPv4 shared address space" do
-						it "will deny with 100.64.0.0" do
-							get api_v1_servers_status_index_path params: {host: "100.64.0.0"}
-
-							json = JSON.parse response.body
-							expect(response).to have_http_status 400
-							expect(json["message"]).to eq "given IP Address is not allowed length."
-						end
-
-						it "will deny with 100.64.0.1" do
-							get api_v1_servers_status_index_path params: {host: "100.64.0.1"}
-
-							json = JSON.parse response.body
-							expect(response).to have_http_status 400
-							expect(json["message"]).to eq "given IP Address is not allowed length."
-						end
-
-						it "will deny with 100.127.255.254" do
-							get api_v1_servers_status_index_path params: {host: "100.127.255.254"}
-
-							json = JSON.parse response.body
-							expect(response).to have_http_status 400
-							expect(json["message"]).to eq "given IP Address is not allowed length."
-						end
-
-						it "will deny with 100.127.255.255" do
-							get api_v1_servers_status_index_path params: {host: "100.127.255.255"}
-
-							json = JSON.parse response.body
-							expect(response).to have_http_status 400
-							expect(json["message"]).to eq "given IP Address is not allowed length."
-						end
-
-						it "will deny with 100.96.64.32" do
-							get api_v1_servers_status_index_path params: {host: "100.96.64.32"}
-
-							json = JSON.parse response.body
-							expect(response).to have_http_status 400
-							expect(json["message"]).to eq "given IP Address is not allowed length."
-						end
-					end
-
-					context "IPv6 loop-back" do
+					context "IPv6 addresses" do
 						it "will deny with ::1" do
 							get api_v1_servers_status_index_path params: {host: "::1"}
 
@@ -282,160 +44,22 @@ RSpec.describe "Api::V1::Servers::Statuses", type: :request do
 							expect(response).to have_http_status 400
 							expect(json["message"]).to eq "given IP Address is not allowed length."
 						end
-					end
 
-					context "IPv6 unique local addresses" do
-						it "will deny with fc00:0000:0000:0000:0000:0000:0000:0000" do
-							get api_v1_servers_status_index_path params: {host: "fc00:0000:0000:0000:0000:0000:0000:0000"}
-
-							json = JSON.parse response.body
-							expect(response).to have_http_status 400
-							expect(json["message"]).to eq "given IP Address is not allowed length."
-						end
-
-						it "will deny with fc00:0000:0000:0000:0000:0000:0000:0001" do
-							get api_v1_servers_status_index_path params: {host: "fc00:0000:0000:0000:0000:0000:0000:0001"}
-
-							json = JSON.parse response.body
-							expect(response).to have_http_status 400
-							expect(json["message"]).to eq "given IP Address is not allowed length."
-						end
-
-						it "will deny with fdff:ffff:ffff:ffff:ffff:ffff:ffff:fffe" do
-							get api_v1_servers_status_index_path params: {host: "fdff:ffff:ffff:ffff:ffff:ffff:ffff:fffe"}
-
-							json = JSON.parse response.body
-							expect(response).to have_http_status 400
-							expect(json["message"]).to eq "given IP Address is not allowed length."
-						end
-
-						it "will deny with fdff:ffff:ffff:ffff:ffff:ffff:ffff:ffff" do
-							get api_v1_servers_status_index_path params: {host: "fdff:ffff:ffff:ffff:ffff:ffff:ffff:ffff"}
-
-							json = JSON.parse response.body
-							expect(response).to have_http_status 400
-							expect(json["message"]).to eq "given IP Address is not allowed length."
-						end
-
-						it "will deny with fd00:cafe:cafe:cafe:cafe:cafe:cafe:cafe (No reason)" do
+						it "will deny with fd00:cafe:cafe:cafe:cafe:cafe:cafe:cafe" do
 							get api_v1_servers_status_index_path params: {host: "fd00:cafe:cafe:cafe:cafe:cafe:cafe:cafe"}
 
 							json = JSON.parse response.body
 							expect(response).to have_http_status 400
 							expect(json["message"]).to eq "given IP Address is not allowed length."
 						end
-					end
 
-					context "IPv6 link local addresses" do
-						it "will deny with fe80:0000:0000:0000:0000:0000:0000:0000" do
-							get api_v1_servers_status_index_path params: {host: "fe80:0000:0000:0000:0000:0000:0000:0000"}
-
-							json = JSON.parse response.body
-							expect(response).to have_http_status 400
-							expect(json["message"]).to eq "given IP Address is not allowed length."
-						end
-
-						it "will deny with fe80:0000:0000:0000:0000:0000:0000:0001" do
-							get api_v1_servers_status_index_path params: {host: "fe80:0000:0000:0000:0000:0000:0000:0001"}
-
-							json = JSON.parse response.body
-							expect(response).to have_http_status 400
-							expect(json["message"]).to eq "given IP Address is not allowed length."
-						end
-
-						it "will deny with febf:ffff:ffff:ffff:ffff:ffff:ffff:fffe" do
-							get api_v1_servers_status_index_path params: {host: "febf:ffff:ffff:ffff:ffff:ffff:ffff:fffe"}
-
-							json = JSON.parse response.body
-							expect(response).to have_http_status 400
-							expect(json["message"]).to eq "given IP Address is not allowed length."
-						end
-
-						it "will deny with febf:ffff:ffff:ffff:ffff:ffff:ffff:ffff" do
-							get api_v1_servers_status_index_path params: {host: "febf:ffff:ffff:ffff:ffff:ffff:ffff:ffff"}
-
-							json = JSON.parse response.body
-							expect(response).to have_http_status 400
-							expect(json["message"]).to eq "given IP Address is not allowed length."
-						end
-
-						it "will deny with febf:beef:beef:beef:beef:beef:beef:beef (No reason)" do
+						it "will deny with febf:beef:beef:beef:beef:beef:beef:beef" do
 							get api_v1_servers_status_index_path params: {host: "febf:beef:beef:beef:beef:beef:beef:beef"}
 
 							json = JSON.parse response.body
 							expect(response).to have_http_status 400
 							expect(json["message"]).to eq "given IP Address is not allowed length."
 						end
-					end
-
-					context "IPv6 multicast address on interface local" do
-						it "will deny with ff01::1" do
-							get api_v1_servers_status_index_path params: {host: "ff01::1"}
-
-							json = JSON.parse response.body
-							expect(response).to have_http_status 400
-							expect(json["message"]).to eq "given IP Address is not allowed length."
-						end
-
-						it "will deny with ff01:0000:0000:0000:0000:0000:0000:0001" do
-							get api_v1_servers_status_index_path params: {host: "ff01:0000:0000:0000:0000:0000:0000:0001"}
-
-							json = JSON.parse response.body
-							expect(response).to have_http_status 400
-							expect(json["message"]).to eq "given IP Address is not allowed length."
-						end
-					end
-
-					context "IPv6 multicast address on link local" do
-						it "will deny with ff02::1" do
-							get api_v1_servers_status_index_path params: {host: "ff01::1"}
-
-							json = JSON.parse response.body
-							expect(response).to have_http_status 400
-							expect(json["message"]).to eq "given IP Address is not allowed length."
-						end
-
-						it "will deny with ff02:0000:0000:0000:0000:0000:0000:0001" do
-							get api_v1_servers_status_index_path params: {host: "ff01:0000:0000:0000:0000:0000:0000:0001"}
-
-							json = JSON.parse response.body
-							expect(response).to have_http_status 400
-							expect(json["message"]).to eq "given IP Address is not allowed length."
-						end
-					end
-				end
-
-				context "deny cases by domains" do
-					it "will deny with not exsits top level domain" do
-						get api_v1_servers_status_index_path params: {host: "minecraft.example.com.hogehoge"}
-
-						json = JSON.parse response.body
-						expect(response).to have_http_status 400
-						expect(json["message"]).to eq "given TLD of hostname is not correct."
-					end
-
-					it "will deny with .local domain" do
-						get api_v1_servers_status_index_path params: {host: "example.local"}
-
-						json = JSON.parse response.body
-						expect(response).to have_http_status 400
-						expect(json["message"]).to eq "given TLD of hostname is not correct."
-					end
-
-					it "will deny with localhost domain" do
-						get api_v1_servers_status_index_path params: {host: "localhost"}
-
-						json = JSON.parse response.body
-						expect(response).to have_http_status 400
-						expect(json["message"]).to eq "given TLD of hostname is not correct."
-					end
-
-					it "will deny with hogehoge-pc domain" do
-						get api_v1_servers_status_index_path params: {host: "hogehoge-pc"}
-
-						json = JSON.parse response.body
-						expect(response).to have_http_status 400
-						expect(json["message"]).to eq "given host is not IP address or correct hostname."
 					end
 				end
 			end


### PR DESCRIPTION
Revert したので再度 PR

## Revert 前の状態からのバグ修正
- close #55 
- tld_list の中身がStringであることのバリデーションをコメントアウト

## 概要
- Server Status API の ACL 実装を別クラスに分割
- 別クラスに分離したACLクラスに対して網羅的な単体テスト
- Server Status API の Request Spec の整理(こちらでACLのテストを網羅的に実施するのはtoo heavy)

## このPRで実施しないこと
- ACLクラス
	- #52 
	- #40 
- Server Status API
	- #38 

## 関連Issue
- close #39 
