### PR TITLE
[fix] validation of ACL class, update ianatld2yaml image.

### DIFF
--- a/Dockerfile.prod
+++ b/Dockerfile.prod
@@ -1,4 +1,4 @@
-FROM tkycraft/ianatld2yaml:2023-09-29_00-00 as tld_list_maker
+FROM tkycraft/ianatld2yaml:2023-10-15_00-50 as tld_list_maker
 RUN perl ianaTLD2yaml.pl
 
 FROM ruby:3.2.2-slim-bullseye

--- a/lib/acl/acl.rb
+++ b/lib/acl/acl.rb
@@ -67,10 +67,10 @@ module Acl
 		private def is_tld_array? _array
 			return false unless _array.class == Array
 			return false if _array.size < 1
-			# _array.each do |_tld|   # Issue #53
+			_array.each do |_tld|
 				# TODO: check simple domains or XN== domains or not.
-				# return false unless _tld.class == String
-			# end
+				return false unless _tld.class == String
+			end
 			return true
 		end
 	end

--- a/spec/lib/acl/acl_spec.rb
+++ b/spec/lib/acl/acl_spec.rb
@@ -49,8 +49,7 @@ RSpec.describe Acl::Acl do
 						expect{Acl::Acl.new "example.com", []}.to raise_error ArgumentError
 					end
 
-					xit "raise error by tld_list is Array of numbers." do
-						# Issue #53
+					it "raise error by tld_list is Array of numbers." do
 						expect{Acl::Acl.new "example.com", [1,2,3]}.to raise_error ArgumentError
 					end
 				end


### PR DESCRIPTION
## 概要
- ianatld2yaml のアップデートにより TLD list がダブルクォーテーションで囲われるように
	- NO ドメインを Ruby の YAML parser が falseと解釈する問題は対応不要になった
- #55 の暫定対応は上のアップデートにより不要になったので、TLD list が文字列配列であることの validation を復活
