### PR TITLE
[feature] Access Control Allow Origin を Response Header に追加

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -1,4 +1,5 @@
 class ApplicationController < ActionController::API
+	before_action :set_response_header
 
 	def render_status _status=500, _data={}, _messages=[]
 		# guard
@@ -41,5 +42,9 @@ class ApplicationController < ActionController::API
 		else
 			raise NotImplementedError
 		end
+	end
+
+	private def set_response_header
+		response.headers['Access-Control-Allow-Origin'] = "*"
 	end
 end

--- a/spec/requests/api/v1/servers/status_spec.rb
+++ b/spec/requests/api/v1/servers/status_spec.rb
@@ -5,6 +5,7 @@ RSpec.describe "Api::V1::Servers::Statuses", type: :request do
 		# it "returns http success" do
 		# 	get api_v1_servers_status_index_path params: {host: ""}
 		# 	expect(response).to have_http_status(200)
+		#	expect(response.headers["Access-Control-Allow-Origin"]).to eq "*"
 		# end
 
 		context "parameters" do

--- a/spec/requests/api/v1/texture/face_spec.rb
+++ b/spec/requests/api/v1/texture/face_spec.rb
@@ -9,6 +9,8 @@ RSpec.describe "Api::V1::Texture::Faces", type: :request do
 
 				# Assert
 				expect(response).to have_http_status 200
+				expect(response.headers["Content-Type"]).to eq "image/png"
+				expect(response.headers["Access-Control-Allow-Origin"]).to eq "*"
 			end
 
 			it "success 200 with correct size params" do


### PR DESCRIPTION
## 概要
- `Access-Control-Allow-Origin` header を `*` に設定する
- Web client の Origin 制約のため

## 関連Issue
- close #59 
