### PR TITLE
[feature] face API の query parameter で キャッシュしないよう指定できるようにする

### DIFF
--- a/app/controllers/api/v1/texture/face_controller.rb
+++ b/app/controllers/api/v1/texture/face_controller.rb
@@ -39,7 +39,7 @@ class Api::V1::Texture::FaceController < ApplicationController
 		return 8 <= @s && @s <= 2048 && @s%8==0 ? @s : false
 	end
 
-	private def should_be_cached?
+	private def use_cache?
 		param = params[:cache]
 		return true if param.nil?
 		return false if param.downcase == "no"

--- a/app/controllers/api/v1/texture/face_controller.rb
+++ b/app/controllers/api/v1/texture/face_controller.rb
@@ -1,4 +1,6 @@
 class Api::V1::Texture::FaceController < ApplicationController
+	before_action :set_cache_control_header
+
 	def show
 		@status = 200
 		@path = URI.parse(request.fullpath).path
@@ -22,7 +24,6 @@ class Api::V1::Texture::FaceController < ApplicationController
 			@status = 404
 		end
 
-		expires_in 1.hours, public: true   # cache-control header.
 		send_data @image_bin, type: "image/png", disposition: 'inline', status: @status
 	end
 
@@ -36,5 +37,20 @@ class Api::V1::Texture::FaceController < ApplicationController
 		return false if /^[0-9]{1,4}$/.match(params[:size]).nil?
 		@s = params[:size].to_i
 		return 8 <= @s && @s <= 2048 && @s%8==0 ? @s : false
+	end
+
+	private def should_be_cached?
+		param = params[:cache]
+		return true if param.nil?
+		return false if param.downcase == "no"
+		return true
+	end
+
+	private def set_cache_control_header
+		if should_be_cached?
+			expires_in 1.hours, public: true
+		else
+			expires_now
+		end
 	end
 end

--- a/app/controllers/api/v1/texture/face_controller.rb
+++ b/app/controllers/api/v1/texture/face_controller.rb
@@ -47,7 +47,7 @@ class Api::V1::Texture::FaceController < ApplicationController
 	end
 
 	private def set_cache_control_header
-		if should_be_cached?
+		if use_cache?
 			expires_in 1.hours, public: true
 		else
 			expires_now

--- a/spec/requests/api/v1/texture/face_spec.rb
+++ b/spec/requests/api/v1/texture/face_spec.rb
@@ -10,7 +10,10 @@ RSpec.describe "Api::V1::Texture::Faces", type: :request do
 				# Assert
 				expect(response).to have_http_status 200
 				expect(response.headers["Content-Type"]).to eq "image/png"
+
 				expect(response.headers["Access-Control-Allow-Origin"]).to eq "*"
+				expect(response.headers["Cache-Control"]).to include "max-age=3600"
+				expect(response.headers["Cache-Control"]).to include "public"
 			end
 
 			it "success 200 with correct size params" do
@@ -20,6 +23,44 @@ RSpec.describe "Api::V1::Texture::Faces", type: :request do
 				# Assert
 				expect(response).to have_http_status 200
 				expect(response.headers["Content-Type"]).to eq "image/png"
+			end
+		end
+
+		context "give cache parameter" do
+			it "returns 200 with no-cache when giving cache=no" do
+				# Act
+				get api_v1_texture_face_path "KrisJelbring.png", {cache: "no"}
+
+				# Assert
+				expect(response).to have_http_status 200
+				expect(response.headers["Cache-Control"]).to include "no-cache"
+			end
+
+			it "returns public when giving cache=yes" do
+				# Act
+				get api_v1_texture_face_path "KrisJelbring.png", {cache: "yes"}
+
+				# Assert
+				expect(response).to have_http_status 200
+				expect(response.headers["Cache-Control"]).to include "public"
+			end
+
+			it "returns public when giving cache=false" do
+				# Act
+				get api_v1_texture_face_path "KrisJelbring.png", {cache: "false"}
+
+				# Assert
+				expect(response).to have_http_status 200
+				expect(response.headers["Cache-Control"]).to include "public"
+			end
+
+			it "returns public when giving cache=0" do
+				# Act
+				get api_v1_texture_face_path "KrisJelbring.png", {cache: "0"}
+
+				# Assert
+				expect(response).to have_http_status 200
+				expect(response.headers["Cache-Control"]).to include "public"
 			end
 		end
 


### PR DESCRIPTION
## 概要
- Query parameter で キャッシュしない旨を指定できるよう変更

## 詳細
- Query parameter で `?cache=no` を指定したとき、response header の Cache-Control に `no-cache` をしていすることで、CDNサービスやブラウザキャッシュを無効にする。
- Rspec の追加
	- `?cache=no` のときCache-Control Header に `no-cache` を含んで response すること、
	- `?cache=no` でないとき(指定しない場合も) Cache-Control Header が `public` であること

## 関連Issue
- close #50 
