### PR TITLE
REVERT! : Update ruby Docker tag to v3.3.0 PR by Renovate

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM ruby:3.3.0-slim-bullseye
+FROM ruby:3.2.2-slim-bullseye
 
 WORKDIR /opt/app
 

--- a/Dockerfile.prod
+++ b/Dockerfile.prod
@@ -1,7 +1,7 @@
 FROM tkycraft/ianatld2yaml:2023-10-15_00-50 as tld_list_maker
 RUN perl ianaTLD2yaml.pl
 
-FROM ruby:3.3.0-slim-bullseye
+FROM ruby:3.2.2-slim-bullseye
 
 WORKDIR /opt/app
 

--- a/Gemfile
+++ b/Gemfile
@@ -1,7 +1,7 @@
 source "https://rubygems.org"
 git_source(:github) { |repo| "https://github.com/#{repo}.git" }
 
-ruby "3.3.0"
+ruby "3.2.2"
 
 # Bundle edge Rails instead: gem "rails", github: "rails/rails", branch: "main"
 gem "rails", "~> 7.1.0"


### PR DESCRIPTION
This reverts commit c253dd25c18d75193947b8ede3360e4682f7a28d.

## references
- #68 