### PR TITLE
fix: add 0.0.0.0/8 to deny rule. "this host"

### DIFF
--- a/lib/acl/acl.rb
+++ b/lib/acl/acl.rb
@@ -5,6 +5,7 @@ module Acl
 
 		DENY_IP_ADDRESSES = [
 			# IPv4
+			"0.0.0.0/8",   # This host on this network
 			"192.168.0.0/16",
 			"172.16.0.0/12",
 			"10.0.0.0/8",

--- a/spec/lib/acl/acl_spec.rb
+++ b/spec/lib/acl/acl_spec.rb
@@ -59,6 +59,25 @@ RSpec.describe Acl::Acl do
 		describe "filter!" do
 			context "deny cases" do
 				context "deny cases by ip address" do
+					context "IPv4 this host" do
+						context "0.0.0.0/8" do
+							it "will deny with 0.0.0.0" do
+								acl = Acl::Acl.new "0.0.0.0", ["COM"]
+								expect{acl.filter!}.to raise_error Acl::DeniedHostError, "given IP Address is not allowed length."
+							end
+
+							it "will deny with 0.255.255.255" do
+								acl = Acl::Acl.new "0.255.255.255", ["COM"]
+								expect{acl.filter!}.to raise_error Acl::DeniedHostError, "given IP Address is not allowed length."
+							end
+
+							it "will deny with 0.0.0.1" do
+								acl = Acl::Acl.new "0.0.0.1", ["COM"]
+								expect{acl.filter!}.to raise_error Acl::DeniedHostError, "given IP Address is not allowed length."
+							end
+						end
+					end
+
 					context "IPv4 local addresses" do
 						context "192.168.x.x" do
 							it "will deny with 192.168.0.0" do
@@ -371,6 +390,10 @@ RSpec.describe Acl::Acl do
 	describe "CONST_VALUES" do
 		describe "DENY_IP_ADDRESSES" do
 			context "IPv4" do
+				it "contains 0.0.0.0/8" do
+					expect(Acl::Acl::DENY_IP_ADDRESSES).to include("0.0.0.0/8")
+				end
+
 				it "contains 192.168.0.0/16" do
 					expect(Acl::Acl::DENY_IP_ADDRESSES).to include("192.168.0.0/16")
 				end


### PR DESCRIPTION
## summary
- add 0.0.0.0/8 to deny rule.
- add Rspec.

# references
- [RFC 6890 section 2.2.2 IPv4 Special-Purpose Address Registry Entries](https://datatracker.ietf.org/doc/html/rfc6890#section-2.2.2)