### PR TITLE
Update use cache to Docker build with GHA

### DIFF
--- a/.github/workflows/docker-build-prod.yaml
+++ b/.github/workflows/docker-build-prod.yaml
@@ -3,6 +3,14 @@ on:
   push:
     branches: 
       - "main"
+  workflow_dispatch:
+    inputs:
+      disable-cache:
+        description: "Unuse docker build cache"
+        default: false
+        required: false
+        type: boolean
+        
 jobs:
   docker:
     runs-on: ubuntu-latest
@@ -36,6 +44,7 @@ jobs:
           platforms: linux/amd64,linux/arm64
           cache-from: type=gha
           cache-to: type=gha,mode=max
+          no-cache: ${{ inputs.disable-cache == true }}
           push: true
           tags: |
             ${{ secrets.DOCKERHUB_USERNAME }}/chisato:${{ env.BUILD_DATETIME }}

--- a/.github/workflows/docker-build-prod.yaml
+++ b/.github/workflows/docker-build-prod.yaml
@@ -34,6 +34,8 @@ jobs:
           context: .
           file: Dockerfile.prod
           platforms: linux/amd64,linux/arm64
+          cache-from: type=gha
+          cache-to: type=gha,mode=max
           push: true
           tags: |
             ${{ secrets.DOCKERHUB_USERNAME }}/chisato:${{ env.BUILD_DATETIME }}


### PR DESCRIPTION
Docker build短くなることを願って（？
https://docs.docker.com/build/ci/github-actions/cache/#github-cache

---
14分は長すぎるｯﾋﾟ
![image](https://github.com/TKYcraft/chisato/assets/54524362/e96354cf-e06e-494e-822f-71b94880b049)

