### PR TITLE
fix: replace `docker-compose` command to `docker compose`

### DIFF
--- a/.github/workflows/rspec.yml
+++ b/.github/workflows/rspec.yml
@@ -14,7 +14,7 @@ jobs:
     - name: build
       shell: bash
       run: |
-        docker-compose -f compose.yaml -f compose.rspec.yaml build
+        docker compose -f compose.yaml -f compose.rspec.yaml build
     - name: exec rspec
       run:  |
-        docker-compose -f compose.yaml -f compose.rspec.yaml run app sh entrypoint_test.sh
+        docker compose -f compose.yaml -f compose.rspec.yaml run app sh entrypoint_test.sh


### PR DESCRIPTION
## summary
- replace `docker-compose` command to `docker compose`.
- old `docker-compose` [command is removed from Actions Runner Image](https://github.com/actions/runner-images/releases/tag/ubuntu22%2F20240730.2).

## issues
- close #131 