### PR TITLE
feature: simple port validation in mc status api.

### DIFF
--- a/app/controllers/api/v1/servers/status_controller.rb
+++ b/app/controllers/api/v1/servers/status_controller.rb
@@ -1,4 +1,6 @@
 class Api::V1::Servers::StatusController < ApplicationController
+	MC_PORT_ALLOW_MORE_THAN = App::Application.config.mc_port_allow_more_than
+
 	def index
 		@tld_list = App::Application.config.tld_list["TLD"]
 		@host = params[:host]
@@ -6,6 +8,9 @@ class Api::V1::Servers::StatusController < ApplicationController
 		@port = params[:port].to_i unless params[:port].nil?
 
 		begin
+			if @port.present?
+				raise ArgumentError unless MC_PORT_ALLOW_MORE_THAN < @port
+			end
 
 			@acl = Acl::Acl.new @host, @tld_list
 			@acl.filter!

--- a/compose.yaml
+++ b/compose.yaml
@@ -6,6 +6,8 @@ services:
       dockerfile: ./Dockerfile
     image: "tkycraft/chisato:ruby3-rails7-0.0.1"
     container_name: chisato-server
+    # environment:
+      # - MC_PORT_ALLOW_MORE_THAN=1023
     volumes:
       - .:/opt/app/
     ports:

--- a/config/application.rb
+++ b/config/application.rb
@@ -43,6 +43,9 @@ module App
     end
     config.tld_list = tld_list
 
+    config.mc_port_allow_more_than = ENV["MC_PORT_ALLOW_MORE_THAN"] || 1023
+    config.mc_port_allow_more_than = config.mc_port_allow_more_than.to_i
+
     # Don't generate system test files.
     config.generators.system_tests = nil
   end

--- a/spec/requests/api/v1/servers/status_spec.rb
+++ b/spec/requests/api/v1/servers/status_spec.rb
@@ -9,6 +9,32 @@ RSpec.describe "Api::V1::Servers::Statuses", type: :request do
 		# end
 
 		context "parameters" do
+			context "port validation" do
+				context "default: 1023" do
+					xit "returns 1023"
+				end
+
+				context "8888" do
+					before do
+						stub_const("Api::V1::Servers::StatusController::MC_PORT_ALLOW_MORE_THAN", 8888)
+					end
+
+					context "8887" do
+						xit "deny request" do
+							expect(Api::V1::Servers::StatusController::MC_PORT_ALLOW_MORE_THAN).to eq 8888
+						end
+					end
+
+					context "8888" do
+						xit "deny request"
+					end
+
+					context "8889" do
+						xit "allow request"
+					end
+				end
+			end
+
 			context "host" do
 				context "deny cases by ip address" do
 					context "IPv4 addresses" do


### PR DESCRIPTION
## summary
- default (1023) or 環境変数で指定した 値より大きな値の port 番号への Status のリクエストを許可するような チェックを追加
- Rspec を追加
- `App::Application.config.mc_port_allow_more_than` を追加

## references
- close #137 