### PR TITLE
feat: server status API で players を sort して返す option の実装, version の返却

### DIFF
--- a/app/controllers/api/v1/servers/status_controller.rb
+++ b/app/controllers/api/v1/servers/status_controller.rb
@@ -41,10 +41,13 @@ class Api::V1::Servers::StatusController < ApplicationController
 	private def convert _status, _sort
 		raise ArgumentError unless _status.class == Hash
 
-		players = if _sort
-			_status["players"]["sample"].sort
-		else
-			_status["players"]["sample"]
+		players = _status["players"]["sample"]
+		players = [] if players.nil?
+
+		if _sort
+			players = players.sort do |a, b|
+				a["name"] <=> b["name"]
+			end
 		end
 
 		return {

--- a/app/controllers/api/v1/servers/status_controller.rb
+++ b/app/controllers/api/v1/servers/status_controller.rb
@@ -48,6 +48,8 @@ class Api::V1::Servers::StatusController < ApplicationController
 		end
 
 		return {
+			version: _status["version"]["name"],
+			protocol: _status["version"]["protocol"],
 			name: _status["description"]["extra"][0]["text"],
 			max_players: _status["players"]["max"],
 			online_players: _status["players"]["online"],

--- a/app/controllers/api/v1/servers/status_controller.rb
+++ b/app/controllers/api/v1/servers/status_controller.rb
@@ -6,6 +6,8 @@ class Api::V1::Servers::StatusController < ApplicationController
 		@host = params[:host]
 		@port = nil
 		@port = params[:port].to_i unless params[:port].nil?
+		@sort = cast_bool(params[:sort].to_s)
+
 
 		begin
 			if @port.present?
@@ -33,17 +35,27 @@ class Api::V1::Servers::StatusController < ApplicationController
 			render status: 500, json: {message: e.message}
 			return
 		end
-		render status: 200, json: convert(@server.status)
+		render status: 200, json: convert(@server.status, @sort)
 	end
 
-	private def convert _status
+	private def convert _status, _sort
 		raise ArgumentError unless _status.class == Hash
+
+		players = if _sort
+			_status["players"]["sample"].sort
+		else
+			_status["players"]["sample"]
+		end
 
 		return {
 			name: _status["description"]["extra"][0]["text"],
 			max_players: _status["players"]["max"],
 			online_players: _status["players"]["online"],
-			players: _status["players"]["sample"]
+			players: players
 		}
+	end
+
+	def cast_bool(str=false)
+		return ["TRUE", "1", "YES", "Y", "T"].include?(str.upcase)
 	end
 end


### PR DESCRIPTION
## summary
- server status api
	- players の sort option の実装
		- sort option (任意) に true / yes / 1 / t / y を渡した場合、players をソートして出力
		- `/api/v1/servers/status?host=mondcraft.alicey.dev&sort=1`
	- version, protocol を返すように変更

## not todo
- テストの実装 (既存の実装が薄いため, 別タスクで実施)

## references
- close #163 