### PR TITLE
feat: sort option の廃止, order option の追加

### DIFF
--- a/app/controllers/api/v1/servers/status_controller.rb
+++ b/app/controllers/api/v1/servers/status_controller.rb
@@ -58,7 +58,7 @@ class Api::V1::Servers::StatusController < ApplicationController
 		raise ArgumentError unless _players.class == Array
 		players = _players
 
-		if _order == "asc"
+		if _order.downcase == "asc"
 			players = players.sort do |a, b|
 				a["name"] <=> b["name"]
 			end

--- a/app/controllers/api/v1/servers/status_controller.rb
+++ b/app/controllers/api/v1/servers/status_controller.rb
@@ -63,7 +63,7 @@ class Api::V1::Servers::StatusController < ApplicationController
 				a["name"] <=> b["name"]
 			end
 		end
-		if _order == "desc"
+		if _order.downcase == "desc"
 			players = players.sort do |a, b|
 				b["name"] <=> a["name"]
 			end


### PR DESCRIPTION
## summary
- server status api
	- players の sort option の廃止
	- players の order option の実装
		- asc
			- order option に asc を渡した場合、players を昇順にソートして返却
			- `/api/v1/servers/status?host=<hostname>&sort=asc`
		- desc
			- order option に desc を渡した場合、players を降順にソートして返却
			- `/api/v1/servers/status?host=<hostname>&sort=desc`
		- 指定無し
			- players をソートせず、Minecraft server から返された順で返却

## not todo
- テストの実装 (既存の実装が薄いため, 別タスクで実施)

## references
- 関連: #167 