### PR TITLE
fix: fetch skin images via Net::HTTP to avoid ImageMagick HTTP policy restriction

### DIFF
--- a/app/controllers/api/v1/texture/face_controller.rb
+++ b/app/controllers/api/v1/texture/face_controller.rb
@@ -18,6 +18,7 @@ class Api::V1::Texture::FaceController < ApplicationController
 		begin
 			@image_bin = request_face_image_of(params[:id], @size).to_blob
 		rescue => e
+			Rails.logger.warn "[FaceController] fallback to steve: #{e.class}: #{e.message}"
 			@image_bin = steve_face_image.to_blob
 			@status = 404
 		end

--- a/lib/minetools/face_tool/face.rb
+++ b/lib/minetools/face_tool/face.rb
@@ -126,8 +126,22 @@ module Minetools
 				return json
 			end
 
-			def http_get(_parsed_uri)
-				Net::HTTP.get(_parsed_uri)
+			def http_get(_parsed_uri, _redirect_limit=1)
+				response = Net::HTTP.start(_parsed_uri.host, _parsed_uri.port,
+						use_ssl: _parsed_uri.scheme == "https",
+						open_timeout: 5, read_timeout: 5) do |http|
+					http.get(_parsed_uri.request_uri)
+				end
+
+				case response
+				when Net::HTTPSuccess
+					response.body
+				when Net::HTTPRedirection
+					raise APIRequestError, "too many redirects." if _redirect_limit <= 0
+					http_get(URI.join(_parsed_uri.to_s, response["location"]), _redirect_limit - 1)
+				else
+					raise APIRequestError, "unexpected response status #{response.code}."
+				end
 			end
 		end
 

--- a/lib/minetools/face_tool/face.rb
+++ b/lib/minetools/face_tool/face.rb
@@ -89,7 +89,14 @@ module Minetools
 			end
 
 			def get_image_from(_url)
-				Magick::Image.read(_url).first
+				parsed_uri = URI.parse(_url)
+				# ImageMagick's HTTP coder is disabled by Debian's security policy,
+				# so fetch remote images with Net::HTTP and decode from blob.
+				if parsed_uri.kind_of? URI::HTTP   # covers both URI::HTTP and URI::HTTPS
+					Magick::Image.from_blob(http_get(parsed_uri)).first
+				else
+					Magick::Image.read(_url).first
+				end
 			end
 
 			def request_json _url=""

--- a/spec/lib/minetools/face_tool/face_spec.rb
+++ b/spec/lib/minetools/face_tool/face_spec.rb
@@ -401,6 +401,93 @@ RSpec.describe Minetools::FaceTool::Face do
 			end
 		end
 
+		describe "http_get()" do
+			let(:parsed_uri){ URI.parse("http://textures.minecraft.net/texture/b47b21bb3e7f79bdf2a5e8e041f7ff9e178dc15645f6449b8e55f906604c07f9") }
+			let(:success_response){
+				_res = Net::HTTPOK.new("1.1", "200", "OK")
+				allow(_res).to receive(:body).and_return("PNG_BINARY")
+				_res
+			}
+			let(:redirect_response){
+				_res = Net::HTTPMovedPermanently.new("1.1", "301", "Moved Permanently")
+				_res["location"] = "https://textures.minecraft.net/texture/b47b21bb3e7f79bdf2a5e8e041f7ff9e178dc15645f6449b8e55f906604c07f9"
+				_res
+			}
+
+			before do
+				allow(face).to receive(:http_get).and_call_original
+			end
+
+			context "response is 200" do
+				before do
+					allow(Net::HTTP).to receive(:start).and_return(success_response)
+				end
+
+				it "returns response body" do
+					expect(face.http_get parsed_uri).to eq "PNG_BINARY"
+				end
+
+				it "connects with explicit open/read timeouts" do
+					face.http_get parsed_uri
+
+					expect(Net::HTTP).to have_received(:start).with(
+						"textures.minecraft.net", 80,
+						hash_including(use_ssl: false, open_timeout: 5, read_timeout: 5)
+					)
+				end
+			end
+
+			context "response is 301 once, then 200" do
+				before do
+					allow(Net::HTTP).to receive(:start).and_return(redirect_response, success_response)
+				end
+
+				it "follows the redirect and returns body" do
+					expect(face.http_get parsed_uri).to eq "PNG_BINARY"
+					expect(Net::HTTP).to have_received(:start).twice
+				end
+
+				it "connects to the redirect target with use_ssl" do
+					face.http_get parsed_uri
+
+					expect(Net::HTTP).to have_received(:start).with(
+						"textures.minecraft.net", 443,
+						hash_including(use_ssl: true)
+					)
+				end
+			end
+
+			context "response is 301 repeatedly" do
+				before do
+					allow(Net::HTTP).to receive(:start).and_return(redirect_response)
+				end
+
+				it "raise APIRequestError" do
+					expect{face.http_get parsed_uri}.to raise_error(Minetools::FaceTool::APIRequestError)
+				end
+			end
+
+			context "response is 404" do
+				before do
+					allow(Net::HTTP).to receive(:start).and_return(Net::HTTPNotFound.new("1.1", "404", "Not Found"))
+				end
+
+				it "raise APIRequestError" do
+					expect{face.http_get parsed_uri}.to raise_error(Minetools::FaceTool::APIRequestError)
+				end
+			end
+
+			context "response is 500" do
+				before do
+					allow(Net::HTTP).to receive(:start).and_return(Net::HTTPInternalServerError.new("1.1", "500", "Internal Server Error"))
+				end
+
+				it "raise APIRequestError" do
+					expect{face.http_get parsed_uri}.to raise_error(Minetools::FaceTool::APIRequestError)
+				end
+			end
+		end
+
 		describe "request!()" do
 			context "set name to instance correctly" do
 				let(:face) { described_class.new name: "KrisJelbring" }

--- a/spec/lib/minetools/face_tool/face_spec.rb
+++ b/spec/lib/minetools/face_tool/face_spec.rb
@@ -349,6 +349,58 @@ RSpec.describe Minetools::FaceTool::Face do
 			end
 		end
 
+		describe "get_image_from()" do
+			before do
+				allow(face).to receive(:get_image_from).and_call_original
+			end
+
+			context "give HTTP URL" do
+				before do
+					allow(face).to receive(:http_get).and_return(File.binread('./spec/fixtures/skin_image_fixture.png'))
+				end
+
+				it "returns Magick::Image fetched via http_get" do
+					url = "http://textures.minecraft.net/texture/b47b21bb3e7f79bdf2a5e8e041f7ff9e178dc15645f6449b8e55f906604c07f9"
+					image = face.get_image_from url
+
+					expect(image.class).to eq Magick::Image
+					expect(face).to have_received(:http_get).once
+				end
+
+				it "does not use ImageMagick's HTTP coder (Magick::Image.read)" do
+					allow(Magick::Image).to receive(:read)
+
+					url = "http://textures.minecraft.net/texture/b47b21bb3e7f79bdf2a5e8e041f7ff9e178dc15645f6449b8e55f906604c07f9"
+					face.get_image_from url
+
+					expect(Magick::Image).not_to have_received(:read)
+				end
+			end
+
+			context "give HTTPS URL" do
+				before do
+					allow(face).to receive(:http_get).and_return(File.binread('./spec/fixtures/skin_image_fixture.png'))
+				end
+
+				it "returns Magick::Image fetched via http_get" do
+					url = "https://textures.minecraft.net/texture/b47b21bb3e7f79bdf2a5e8e041f7ff9e178dc15645f6449b8e55f906604c07f9"
+					image = face.get_image_from url
+
+					expect(image.class).to eq Magick::Image
+					expect(face).to have_received(:http_get).once
+				end
+			end
+
+			context "give local file path" do
+				it "returns Magick::Image without http_get" do
+					image = face.get_image_from './spec/fixtures/skin_image_fixture.png'
+
+					expect(image.class).to eq Magick::Image
+					expect(face).not_to have_received(:http_get)
+				end
+			end
+		end
+
 		describe "request!()" do
 			context "set name to instance correctly" do
 				let(:face) { described_class.new name: "KrisJelbring" }


### PR DESCRIPTION
## Problem

`GET /api/v1/texture/face/:id.png` always returned 404 (steve.png fallback), even for valid Minecraft user names.

## Root cause

`Magick::Image.read(url)` in `lib/minetools/face_tool/face.rb` relies on ImageMagick's built-in HTTP fetch. Debian ships ImageMagick with the HTTP/HTTPS coders disabled in `/etc/ImageMagick-6/policy.xml` (mitigation for CVE-2016-3714 "ImageTragick"), so reading the skin URL raised:

```
Magick::ImageMagickError: attempt to perform an operation not allowed by the security policy `HTTP' @ error/constitute.c/IsCoderAuthorized/426
```

The exception was silently swallowed by the controller's rescue, which fell back to steve.png with 404.

Notes from investigation:
- Reproduced on `main` (rmagick v6) as well — this is a pre-existing bug, unrelated to the rmagick v7 update (#247).
- Both Mojang API endpoints and the texture CDN are reachable from the container; only ImageMagick's own HTTP fetch is blocked.

## Fix

- `Minetools::FaceTool::Face#get_image_from` now fetches `http(s)://` URLs with the existing `http_get` (Net::HTTP) and decodes via `Magick::Image.from_blob`. Local file paths (steve.png fallback) keep using `Magick::Image.read`.
- The ImageMagick security policy is intentionally left untouched to preserve its SSRF mitigation.
- `FaceController` now logs the fallback reason (`Rails.logger.warn`) instead of swallowing exceptions silently.
- Added specs for `get_image_from` (HTTP URL, HTTPS URL, local path; asserts ImageMagick's HTTP coder is not used).

## Verification

- `bundle exec rspec` in the container: **194 examples, 0 failures**
- E2E on local Docker:
  - `GET /api/v1/texture/face/KrisJelbring.png` → **200**, valid 512x512 PNG face image
  - `GET /api/v1/texture/face/<non-existent>.png` → **404**, steve.png fallback, warn log shows `GetUUIDError`
  - No `security policy` errors in server logs

## Future improvements (out of scope)

- Migrate to `api.minecraftservices.com` profile lookup endpoints
- Apply `Acl::Acl` validation to the skin URL before fetching

🤖 Generated with [Claude Code](https://claude.com/claude-code)