### PR TITLE
feat: server icon api

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -29,6 +29,7 @@ docker compose ps
 | Controller | Route | Purpose |
 |---|---|---|
 | `Servers::StatusController` | `GET /api/v1/servers/status` | Fetch Minecraft server status via TCP |
+| `Servers::IconController` | `GET /api/v1/servers/icon` | Fetch Minecraft server icon (favicon) as PNG |
 | `Texture::FaceController` | `GET /api/v1/texture/face/:id.png` | Fetch player face image |
 | `HealthCheckController` | `GET /api/v1/health_check` | Health check |
 | `TeapotController` | `GET /api/v1/teapot` | 418 response |

--- a/app/controllers/api/v1/servers/icon_controller.rb
+++ b/app/controllers/api/v1/servers/icon_controller.rb
@@ -1,6 +1,7 @@
 class Api::V1::Servers::IconController < ApplicationController
 	MC_PORT_ALLOW_MORE_THAN = App::Application.config.mc_port_allow_more_than
 	FAVICON_PREFIX = /\Adata:\s*image\/png;base64,/
+	PNG_SIGNATURE = "\x89PNG\r\n\x1a\n".b.freeze
 
 	after_action :set_cache_control_header
 
@@ -49,7 +50,10 @@ class Api::V1::Servers::IconController < ApplicationController
 		return nil unless _favicon.class == String
 		return nil unless FAVICON_PREFIX.match? _favicon
 		encoded = _favicon.sub(FAVICON_PREFIX, "").gsub(/\s+/, "")
-		return Base64.strict_decode64(encoded)
+		decoded = Base64.strict_decode64(encoded)
+		# The declared MIME type is not trustworthy; serve only real PNG data.
+		return nil unless decoded.start_with? PNG_SIGNATURE
+		return decoded
 	rescue ArgumentError
 		return nil
 	end

--- a/app/controllers/api/v1/servers/icon_controller.rb
+++ b/app/controllers/api/v1/servers/icon_controller.rb
@@ -1,0 +1,71 @@
+class Api::V1::Servers::IconController < ApplicationController
+	MC_PORT_ALLOW_MORE_THAN = App::Application.config.mc_port_allow_more_than
+	FAVICON_PREFIX = /\Adata:\s*image\/png;base64,/
+
+	before_action :set_cache_control_header
+
+	def index
+		@tld_list = App::Application.config.tld_list["TLD"]
+		@host = params[:host]
+		@port = nil
+		@port = params[:port].to_i unless params[:port].nil?
+
+		begin
+			if @port.present?
+				raise ArgumentError unless MC_PORT_ALLOW_MORE_THAN < @port
+			end
+
+			@acl = Acl::Acl.new @host, @tld_list
+			@acl.filter!
+			@server = Minetools::ServerStatusTool::ServerStatus.new host: @host, port: @port
+			@server.fetch_status!
+
+		rescue ArgumentError => e
+			render status: 400, json: {message: e.message}
+			return
+		rescue Acl::DeniedHostError => e
+			render status: 400, json: {message: e.message}
+			return
+		rescue Minetools::ServerStatusTool::ServiceUnavailableError => e
+			render status: 404, json: {message: e.message}
+			return
+		rescue Minetools::ServerStatusTool::ConnectionError => e
+			render status: 500, json: {message: e.message}
+			return
+		rescue => e
+			render status: 500, json: {message: e.message}
+			return
+		end
+
+		@icon_bin = decode_favicon @server.status["favicon"]
+		if @icon_bin.nil?
+			head :not_found
+			return
+		end
+		send_data @icon_bin, type: "image/png", disposition: 'inline', status: 200
+	end
+
+	private def decode_favicon _favicon
+		return nil unless _favicon.class == String
+		return nil unless FAVICON_PREFIX.match? _favicon
+		encoded = _favicon.sub(FAVICON_PREFIX, "").gsub(/\s+/, "")
+		return Base64.strict_decode64(encoded)
+	rescue ArgumentError
+		return nil
+	end
+
+	private def use_cache?
+		param = params[:cache]
+		return true if param.nil?
+		return false if param.downcase == "no"
+		return true
+	end
+
+	private def set_cache_control_header
+		if use_cache?
+			expires_in 1.hours, public: true
+		else
+			expires_now
+		end
+	end
+end

--- a/app/controllers/api/v1/servers/icon_controller.rb
+++ b/app/controllers/api/v1/servers/icon_controller.rb
@@ -2,7 +2,7 @@ class Api::V1::Servers::IconController < ApplicationController
 	MC_PORT_ALLOW_MORE_THAN = App::Application.config.mc_port_allow_more_than
 	FAVICON_PREFIX = /\Adata:\s*image\/png;base64,/
 
-	before_action :set_cache_control_header
+	after_action :set_cache_control_header
 
 	def index
 		@tld_list = App::Application.config.tld_list["TLD"]
@@ -62,7 +62,9 @@ class Api::V1::Servers::IconController < ApplicationController
 	end
 
 	private def set_cache_control_header
-		if use_cache?
+		# Cache successful responses only. Caching error responses (400/404/500)
+		# could keep serving stale errors for up to 1 hour after recovery.
+		if response.successful? && use_cache?
 			expires_in 1.hours, public: true
 		else
 			expires_now

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -8,6 +8,7 @@ Rails.application.routes.draw do
       resources :teapot, only: [:index]
       namespace :servers do
         resources :status, only: [:index]
+        resources :icon, only: [:index]
       end
       namespace :texture do
         resources :face, only: [:show]

--- a/spec/requests/api/v1/servers/icon_spec.rb
+++ b/spec/requests/api/v1/servers/icon_spec.rb
@@ -1,0 +1,240 @@
+require 'rails_helper'
+
+RSpec.describe "Api::V1::Servers::Icons", type: :request do
+	describe "index action" do
+		let(:server_status_tool) { instance_spy(Minetools::ServerStatusTool::ServerStatus) }
+		let(:acl_tool) { instance_spy(Acl::Acl) }
+		let(:favicon_bytes) { "fake png bytes" }
+		let(:favicon) { "data:image/png;base64,#{Base64.strict_encode64(favicon_bytes)}" }
+		let(:server_status) { {
+			version: {
+				name: "Spigot 1.20.1",
+				protocol: 763
+			},
+			players: {
+				max: 15,
+				online: 1,
+				sample: [{
+					name: "example",
+					id: "cafecafe-cafe1234"
+				}]
+			},
+			description: {
+				extra: [
+					{text: "Example Server Message."}
+				],
+				text: ""
+			},
+			favicon: favicon,
+			modinfo: {
+				type: "FML",
+				modList: []
+			}
+		}.deep_stringify_keys.freeze }
+
+		before do
+			allow(Minetools::ServerStatusTool::ServerStatus)
+				.to receive(:new)
+				.and_return(server_status_tool)
+
+			allow(server_status_tool)
+				.to receive(:status)
+				.and_return(server_status)
+		end
+
+		context "with stubbed Acl" do
+			before do
+				allow(Acl::Acl)
+					.to receive(:new)
+					.and_return(acl_tool)
+			end
+
+			context "server has a valid favicon" do
+				it "returns decoded png with 200" do
+					# Act
+					get api_v1_servers_icon_index_path, params: {host: "example.com"}
+
+					# Assert
+					expect(response).to have_http_status 200
+					expect(response.headers["Content-Type"]).to eq "image/png"
+					expect(response.body).to eq favicon_bytes
+
+					expect(response.headers["Access-Control-Allow-Origin"]).to eq "*"
+					expect(response.headers["Cache-Control"]).to include "public"
+					expect(response.headers["Cache-Control"]).to include "max-age=3600"
+				end
+			end
+
+			context "favicon has a space after `data:` (existing fixture form)" do
+				let(:favicon) { "data: image/png;base64,#{Base64.strict_encode64(favicon_bytes)}" }
+
+				it "returns decoded png with 200" do
+					# Act
+					get api_v1_servers_icon_index_path, params: {host: "example.com"}
+
+					# Assert
+					expect(response).to have_http_status 200
+					expect(response.headers["Content-Type"]).to eq "image/png"
+					expect(response.body).to eq favicon_bytes
+				end
+			end
+
+			context "give cache parameter" do
+				it "returns 200 with no-cache when giving cache=no" do
+					# Act
+					get api_v1_servers_icon_index_path, params: {host: "example.com", cache: "no"}
+
+					# Assert
+					expect(response).to have_http_status 200
+					expect(response.headers["Cache-Control"]).to include "no-cache"
+				end
+			end
+
+			context "status has no favicon key" do
+				let(:server_status) { {
+					version: {
+						name: "Spigot 1.20.1",
+						protocol: 763
+					},
+					players: {
+						max: 15,
+						online: 1,
+						sample: []
+					},
+					description: {
+						extra: [
+							{text: "Example Server Message."}
+						],
+						text: ""
+					}
+				}.deep_stringify_keys.freeze }
+
+				it "returns 404 with empty body" do
+					# Act
+					get api_v1_servers_icon_index_path, params: {host: "example.com"}
+
+					# Assert
+					expect(response).to have_http_status 404
+					expect(response.body).to be_empty
+				end
+			end
+
+			context "favicon has non-png MIME prefix" do
+				let(:favicon) { "data:image/jpeg;base64,#{Base64.strict_encode64(favicon_bytes)}" }
+
+				it "returns 404 with empty body" do
+					# Act
+					get api_v1_servers_icon_index_path, params: {host: "example.com"}
+
+					# Assert
+					expect(response).to have_http_status 404
+					expect(response.body).to be_empty
+				end
+			end
+
+			context "favicon has invalid base64 payload" do
+				let(:favicon) { "data:image/png;base64,%%%" }
+
+				it "returns 404 with empty body" do
+					# Act
+					get api_v1_servers_icon_index_path, params: {host: "example.com"}
+
+					# Assert
+					expect(response).to have_http_status 404
+					expect(response.body).to be_empty
+				end
+			end
+
+			context "port validation" do
+				context "MC_PORT_ALLOW_MORE_THAN: 8888" do
+					before do
+						stub_const("Api::V1::Servers::IconController::MC_PORT_ALLOW_MORE_THAN", 8888)
+					end
+
+					context "request port: 8887" do
+						it "deny request" do
+							get api_v1_servers_icon_index_path, params: {host: "192.168.0.1", port: 8887}
+
+							expect(Minetools::ServerStatusTool::ServerStatus).not_to have_received(:new)
+							expect(Acl::Acl).not_to have_received(:new)
+
+							expect(response).to have_http_status(400)
+						end
+					end
+
+					context "request port: 8888" do
+						it "deny request" do
+							get api_v1_servers_icon_index_path, params: {host: "192.168.0.1", port: 8888}
+
+							expect(Minetools::ServerStatusTool::ServerStatus).not_to have_received(:new)
+							expect(Acl::Acl).not_to have_received(:new)
+
+							expect(response).to have_http_status(400)
+						end
+					end
+
+					context "request port: 8889" do
+						it "allow request" do
+							get api_v1_servers_icon_index_path, params: {host: "192.168.0.1", port: 8889}
+
+							expect(Minetools::ServerStatusTool::ServerStatus).to have_received(:new).once
+							expect(Acl::Acl).to have_received(:new).once
+
+							expect(response).to have_http_status(200)
+						end
+					end
+				end
+			end
+
+			context "fetch_status! raises ServiceUnavailableError" do
+				before do
+					allow(server_status_tool)
+						.to receive(:fetch_status!)
+						.and_raise Minetools::ServerStatusTool::ServiceUnavailableError, "service unavailable."
+				end
+
+				it "returns 404 with json message" do
+					# Act
+					get api_v1_servers_icon_index_path, params: {host: "example.com"}
+
+					# Assert
+					json = JSON.parse response.body
+					expect(response).to have_http_status 404
+					expect(json["message"]).to eq "service unavailable."
+				end
+			end
+
+			context "fetch_status! raises ConnectionError" do
+				before do
+					allow(server_status_tool)
+						.to receive(:fetch_status!)
+						.and_raise Minetools::ServerStatusTool::ConnectionError, "connection failed."
+				end
+
+				it "returns 500 with json message" do
+					# Act
+					get api_v1_servers_icon_index_path, params: {host: "example.com"}
+
+					# Assert
+					json = JSON.parse response.body
+					expect(response).to have_http_status 500
+					expect(json["message"]).to eq "connection failed."
+				end
+			end
+		end
+
+		context "with real Acl" do
+			context "deny case by private ip address" do
+				it "will deny with 192.168.0.1" do
+					# Act
+					get api_v1_servers_icon_index_path, params: {host: "192.168.0.1"}
+
+					# Assert
+					json = JSON.parse response.body
+					expect(response).to have_http_status 400
+					expect(json["message"]).to eq "given IP Address is not allowed length."
+				end
+			end
+		end
+	end
+end

--- a/spec/requests/api/v1/servers/icon_spec.rb
+++ b/spec/requests/api/v1/servers/icon_spec.rb
@@ -116,6 +116,9 @@ RSpec.describe "Api::V1::Servers::Icons", type: :request do
 					# Assert
 					expect(response).to have_http_status 404
 					expect(response.body).to be_empty
+
+					expect(response.headers["Cache-Control"]).to include "no-cache"
+					expect(response.headers["Cache-Control"]).not_to include "max-age=3600"
 				end
 			end
 
@@ -219,6 +222,9 @@ RSpec.describe "Api::V1::Servers::Icons", type: :request do
 					json = JSON.parse response.body
 					expect(response).to have_http_status 500
 					expect(json["message"]).to eq "connection failed."
+
+					expect(response.headers["Cache-Control"]).to include "no-cache"
+					expect(response.headers["Cache-Control"]).not_to include "max-age=3600"
 				end
 			end
 		end

--- a/spec/requests/api/v1/servers/icon_spec.rb
+++ b/spec/requests/api/v1/servers/icon_spec.rb
@@ -4,7 +4,7 @@ RSpec.describe "Api::V1::Servers::Icons", type: :request do
 	describe "index action" do
 		let(:server_status_tool) { instance_spy(Minetools::ServerStatusTool::ServerStatus) }
 		let(:acl_tool) { instance_spy(Acl::Acl) }
-		let(:favicon_bytes) { "fake png bytes" }
+		let(:favicon_bytes) { "\x89PNG\r\n\x1a\nfake png body".b }
 		let(:favicon) { "data:image/png;base64,#{Base64.strict_encode64(favicon_bytes)}" }
 		let(:server_status) { {
 			version: {
@@ -124,6 +124,19 @@ RSpec.describe "Api::V1::Servers::Icons", type: :request do
 
 			context "favicon has non-png MIME prefix" do
 				let(:favicon) { "data:image/jpeg;base64,#{Base64.strict_encode64(favicon_bytes)}" }
+
+				it "returns 404 with empty body" do
+					# Act
+					get api_v1_servers_icon_index_path, params: {host: "example.com"}
+
+					# Assert
+					expect(response).to have_http_status 404
+					expect(response.body).to be_empty
+				end
+			end
+
+			context "favicon decodes to non-png data" do
+				let(:favicon) { "data:image/png;base64,#{Base64.strict_encode64('not a png binary')}" }
 
 				it "returns 404 with empty body" do
 					# Act


### PR DESCRIPTION
## 概要

Minecraft サーバーのアイコン(favicon)を PNG 画像として返す新エンドポイント `GET /api/v1/servers/icon` を追加します。

status エンドポイントはサーバーから `favicon`(`data:image/png;base64,...`)を含むステータス JSON を取得済みですが、レスポンス生成時に favicon を捨てていました。本 PR は同じデータソース(`Minetools::ServerStatusTool::ServerStatus`)を再利用し、デコード済みの PNG バイナリを返します。`lib/` の変更はありません。

## 変更内容

- `config/routes.rb` — `servers` namespace に `resources :icon, only: [:index]` を追加
- `app/controllers/api/v1/servers/icon_controller.rb`(新規)— host/port/ACL 検証と rescue 連鎖は `StatusController` を踏襲。キャッシュヘッダ(`expires_in 1.hours, public: true`、`cache=no` で無効化)は `FaceController` を踏襲
- `spec/requests/api/v1/servers/icon_spec.rb`(新規)— 成功系・cache パラメータ・不正 favicon・ポート検証・ACL 拒否・上流エラーの 12 例
- `CLAUDE.md` — API エンドポイント表に追記

## 挙動と確認用 path(localhost:3000)

| ケース | レスポンス | 確認用 path |
|---|---|---|
| 正常系(favicon あり) | 200、`image/png` バイナリ(inline) | `/api/v1/servers/icon?host=mc04.alicey.dev` |
| キャッシュ無効化 | 200、`Cache-Control: no-cache` | `/api/v1/servers/icon?host=mc04.alicey.dev&cache=no` |
| favicon 欠落 / 非 PNG MIME / base64 デコード不能 | 404、空ボディ | 公開サーバーでの再現例なし(request spec で担保) |
| 不正ポート(`MC_PORT_ALLOW_MORE_THAN` 以下) | 400、JSON message | `/api/v1/servers/icon?host=mc04.alicey.dev&port=80` |
| ACL 拒否ホスト | 400、JSON message | `/api/v1/servers/icon?host=192.168.0.1` |
| `ServiceUnavailableError`(名前解決不可など) | 404、JSON message | `/api/v1/servers/icon?host=example.com` |
| `ConnectionError` / 予期しないエラー | 500、JSON message | `/api/v1/servers/icon?host=example.com`(Minecraft サーバーではないホスト) |

上記の path はすべてローカル環境で実際にレスポンスコードを確認済みです。
なお、開発用 `config/tld_list.yaml` は COM/JP/DEV/CLICK/GOV のみ許可のため、`.net` のホスト(例: mc.hypixel.net)は 400 になります。

favicon デコードに関する設計上のポイント:

- プレフィックス正規表現 `\Adata:\s*image\/png;base64,` により、実ペイロードに見られるスペース入り形式(`data: image/png;base64,`)を許容しつつ、非 PNG の data URI を拒否します。任意のペイロードが `image/png` として配信されることはありません。
- 寛容な `decode64`(不正文字を黙って捨てる)ではなく、空白除去後の `Base64.strict_decode64` を使用します。デコードはメインの rescue 連鎖の後に実施するため、デコード失敗の `ArgumentError` はポート検証の 400 ではなく 404 になります。

## テスト

- `bundle exec rspec spec/requests/api/v1/servers/icon_spec.rb` — 12 examples, 0 failures
- `bundle exec rspec` — 213 examples, 0 failures(リグレッションなし)
- 手動確認: `GET /api/v1/servers/icon?host=play.wynncraft.com` で正常な 64x64 PNG を取得(`access-control-allow-origin: *`、`cache-control: max-age=3600, public`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)